### PR TITLE
Show the suffix to get the path to the raw captured output when applicable

### DIFF
--- a/core/Run.ml
+++ b/core/Run.ml
@@ -345,7 +345,9 @@ let show_diff (output_kind : string) path_to_expected_output path_to_output =
   | _nonzero ->
       printf "%sCaptured %s differs from expectation.\n" bullet output_kind
 
-let show_output_details (sum : T.status_summary)
+let show_output_details
+    (test : _ T.test)
+    (sum : T.status_summary)
     (output_file_pairs : Store.output_file_pair list) =
   let success = success_of_status_summary sum in
   output_file_pairs
@@ -369,7 +371,11 @@ let show_output_details (sum : T.status_summary)
              if success <> OK_but_new then
                printf "%sPath to expected %s: %s\n" bullet short_name
                  path_to_expected_output);
-         printf "%sPath to captured %s: %s\n" bullet short_name path_to_output)
+         printf "%sPath to captured %s: %s%s\n"
+           bullet short_name path_to_output
+           (match Store.get_orig_output_suffix test with
+            | Some suffix -> sprintf " [%s]" suffix
+            | None -> ""))
 
 let print_error text = printf "%s%s\n" bullet (Style.color Red text)
 
@@ -422,7 +428,7 @@ let print_status ~highlight_test ~always_show_unchecked_output
                      (String.concat ", " paths))
             | Ok _ -> ()));
         let output_file_pairs = Store.get_output_file_pairs test in
-        show_output_details sum output_file_pairs;
+        show_output_details test sum output_file_pairs;
         match success_of_status_summary sum with
         | OK when not always_show_unchecked_output -> ()
         | OK_but_new when not always_show_unchecked_output ->

--- a/core/Store.ml
+++ b/core/Store.ml
@@ -179,6 +179,11 @@ let unchecked_filename = "log"
    of the test output as specified by the option 'mask_output' function. *)
 let orig_suffix = ".orig"
 
+let get_orig_output_suffix (test : _ T.test) =
+  match test.normalize with
+  | [] -> None
+  | _ -> Some orig_suffix
+
 let names_of_output (output : T.output_kind) : string list =
   match output with
   | Ignore_output -> [ unchecked_filename ]
@@ -350,10 +355,10 @@ let compose_functions_left_to_right funcs x =
    unpredicable parts, we rewrite the standard output file and we make a
    backup of the original. *)
 let mask_output (test : 'unit_promise T.test) =
-  match test.normalize with
-  | [] -> ()
-  | mask_functions ->
-      let rewrite_string = compose_functions_left_to_right mask_functions in
+  match get_orig_output_suffix test with
+  | None -> ()
+  | Some orig_suffix ->
+      let rewrite_string = compose_functions_left_to_right test.normalize in
       get_checked_output_paths test
       |> List.iter (fun std_path ->
              let backup_path = std_path ^ orig_suffix in

--- a/core/Store.mli
+++ b/core/Store.mli
@@ -70,6 +70,12 @@ val status_summary_of_status : Types.status -> Types.status_summary
 *)
 val approve_new_output : 'a Types.test -> (unit, string) Result.t
 
+(*
+   If a test is configured to normalize its output, this returns the
+   suffix for the backup file holding the original captured output.
+*)
+val get_orig_output_suffix : 'a Types.test -> string option
+
 (**************************************************************************)
 (* Wrappers for capturing test output *)
 (**************************************************************************)


### PR DESCRIPTION
Closes #17 