### PR TITLE
Exit with a nonzero code if any test needs its output approved

### DIFF
--- a/core/Testo.ml
+++ b/core/Testo.ml
@@ -46,7 +46,15 @@ type status = T.status = {
   result : (result, string list) Result.t;
 }
 
-type status_class = T.status_class = PASS | FAIL | XFAIL | XPASS | MISS
+type fail_reason = T.fail_reason =
+    Exception | Wrong_output | Exception_and_wrong_output
+
+type status_class = T.status_class =
+  | PASS
+  | FAIL of fail_reason
+  | XFAIL of fail_reason
+  | XPASS
+  | MISS
 
 type status_summary = T.status_summary = {
   status_class : status_class;

--- a/core/Testo.mli
+++ b/core/Testo.mli
@@ -18,6 +18,9 @@
 (****************************************************************************)
 (* A bunch of types for advanced uses and subject to frequent changes. *)
 (****************************************************************************)
+(*
+   These types are documented in Types.ml.
+*)
 
 type expected_outcome =
   | Should_succeed
@@ -43,7 +46,8 @@ type result = { outcome : outcome; captured_output : captured_output }
 
 type expectation = {
   expected_outcome : expected_outcome;
-  expected_output : (expected_output, string list (* missing files *)) Result.t;
+  expected_output :
+    (expected_output, string list (* missing files *)) Result.t;
 }
 
 type status = {
@@ -51,7 +55,14 @@ type status = {
   result : (result, string list) Result.t;
 }
 
-type status_class = PASS | FAIL | XFAIL | XPASS | MISS
+type fail_reason = Exception | Wrong_output | Exception_and_wrong_output
+
+type status_class =
+  | PASS
+  | FAIL of fail_reason
+  | XFAIL of fail_reason
+  | XPASS
+  | MISS
 
 type status_summary = {
   status_class : status_class;

--- a/core/Types.ml
+++ b/core/Types.ml
@@ -60,6 +60,8 @@ type status = {
   result : (result, string list (* missing files *)) Result.t;
 }
 
+type fail_reason = Exception | Wrong_output | Exception_and_wrong_output
+
 (* A summary of the 'status' object using the same language as pytest.
 
    PASS: expected success, actual success
@@ -70,7 +72,12 @@ type status = {
 
    Maximum string length for display: 5 characters
 *)
-type status_class = PASS | FAIL | XFAIL | XPASS | MISS
+type status_class =
+  | PASS
+  | FAIL of fail_reason
+  | XFAIL of fail_reason
+  | XPASS
+  | MISS
 
 type status_summary = {
   status_class : status_class;

--- a/tests/snapshots/testo_dummy_failing_tests/189ed1da5108/stdout
+++ b/tests/snapshots/testo_dummy_failing_tests/189ed1da5108/stdout
@@ -1,6 +1,0 @@
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-quis nostrud exercitation (?) ullamco laboris nisi ut aliquip ex ea commodo
-consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
-cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
The new policy is:

> Exit with a nonzero status if any user action is needed.

Previously, the exit status could be 0 (success) even if some new tests didn't have their output approved and recorded as snapshots.

Also, now we print a reason for a test failing when it's not already clear - this indicates if the test failed due to an exception or due to the output being wrong.