### PR TITLE
Add an optional 'depth' parameter to the function for masking temp paths

### DIFF
--- a/core/Testo.mli
+++ b/core/Testo.mli
@@ -321,8 +321,21 @@ val mask_pcre_pattern : ?mask:string -> string -> (string -> string)
    {- the files placed in the system's temporary folder are assigned
       random names.}
 }
+
+   Options:
+{ul
+   {- [depth]: maximum number of path segments to mask after [/tmp] or
+               equivalent.
+               For example, [/tmp/b4ac9882/foo/bar] will become
+               [<MASKED TEMPORARY PATH>foo/bar] with the default depth
+               of [Some 1]. With a depth of 2, if would become
+               [<MASKED TEMPORARY PATH>bar]}. Use [None] to mask the full
+               path. Use [Some 0] to mask only [/tmp] or equivalent.
+   {- [mask]: replacement string. Defaults to [<MASKED TEMPORARY PATH>].}
+}
 *)
-val mask_temp_paths : ?mask:string -> unit -> (string -> string)
+val mask_temp_paths :
+  ?depth:int option -> ?mask:string -> unit -> (string -> string)
 
 (**
    Keep the given substring and mask everything else.

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -69,6 +69,9 @@ Legend:
 [33m[MISS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/3b24997d50c8/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
+[33m[MISS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e8a3ba3cf9b4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
 [33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d5b0041ea8f4/outcome[0m
@@ -87,8 +90,8 @@ Legend:
 [33m[MISS]  [0m065cc54b852b [36malcotest error formatting[0m
 [2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/065cc54b852b/outcome[0m
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
+[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
 [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/33a93d234d01/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
@@ -188,6 +191,12 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m                                         [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e8a3ba3cf9b4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m                           [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
@@ -216,8 +225,8 @@ Legend:
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/065cc54b852b/outcome[0m
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
+[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m                               [2m│[0m
@@ -237,10 +246,10 @@ Legend:
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b8cd199f2e62/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/b8cd199f2e62/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-21/21 selected tests:
+22/22 selected tests:
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-20 new tests
+21 new tests
 overall status: [31mfailure[0m
 <handling result before exiting>
 RUN ./test run
@@ -298,6 +307,8 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
 [33m[RUN][0m   3b24997d50c8 [36mmask_pcre_pattern[0m...[2K[32m[PASS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
+[33m[RUN][0m   e8a3ba3cf9b4 [36mmask_temp_paths[0m...[2K[32m[PASS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
 [33m[RUN][0m   d5b0041ea8f4 [36mcheck for substring in stdout[0m...[2K[32m[PASS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
@@ -316,8 +327,8 @@ Legend:
 [33m[RUN][0m   065cc54b852b [36malcotest error formatting[0m...[2K[32m[PASS]  [0m065cc54b852b [36malcotest error formatting[0m
 [2m• [0mChecked output: stderr
 [2m• [0mPath to expected stderr: tests/snapshots/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
+[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
 [33m[RUN][0m   33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m...[2K[32m[PASS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
 [33m[RUN][0m   ec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m...[2K[32m[PASS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
@@ -357,8 +368,8 @@ Legend:
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
 [2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-21/21 selected tests:
-  20 successful (19 pass, 1 xfail)
+22/22 selected tests:
+  21 successful (20 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 4 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -420,6 +431,8 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
 [32m[PASS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
+[32m[PASS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
 [32m[PASS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
@@ -438,8 +451,8 @@ Legend:
 [32m[PASS]  [0m065cc54b852b [36malcotest error formatting[0m
 [2m• [0mChecked output: stderr
 [2m• [0mPath to expected stderr: tests/snapshots/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
+[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
 [32m[PASS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
 [32m[PASS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
@@ -480,8 +493,8 @@ Legend:
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
 [2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-21/21 selected tests:
-  20 successful (19 pass, 1 xfail)
+22/22 selected tests:
+  21 successful (20 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 4 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -520,8 +533,8 @@ RUN ./test status --short
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
 [2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-21/21 selected tests:
-  20 successful (19 pass, 1 xfail)
+22/22 selected tests:
+  21 successful (20 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 4 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -585,6 +598,8 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
 [32m[PASS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
+[32m[PASS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
 [32m[PASS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
@@ -603,8 +618,8 @@ Legend:
 [32m[PASS]  [0m065cc54b852b [36malcotest error formatting[0m
 [2m• [0mChecked output: stderr
 [2m• [0mPath to expected stderr: tests/snapshots/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
+[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
 [32m[PASS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
 [32m[PASS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
@@ -612,8 +627,8 @@ Legend:
 [32m[PASS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/b8cd199f2e62/log
 
-21/21 selected tests:
-  20 successful (19 pass, 1 xfail)
+22/22 selected tests:
+  21 successful (20 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m
 <handling result before exiting>
@@ -684,6 +699,9 @@ Legend:
 [33m[MISS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/3b24997d50c8/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
+[33m[MISS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e8a3ba3cf9b4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
 [33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d5b0041ea8f4/outcome[0m
@@ -702,8 +720,8 @@ Legend:
 [33m[MISS]  [0m065cc54b852b [36malcotest error formatting[0m
 [2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/065cc54b852b/outcome[0m
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
+[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
 [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/33a93d234d01/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
@@ -803,6 +821,12 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m                                         [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e8a3ba3cf9b4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m                           [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
@@ -831,8 +855,8 @@ Legend:
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/065cc54b852b/outcome[0m
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
+[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m                               [2m│[0m
@@ -852,10 +876,10 @@ Legend:
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b8cd199f2e62/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/b8cd199f2e62/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-21/21 selected tests:
+22/22 selected tests:
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-20 new tests
+21 new tests
 overall status: [31mfailure[0m
 <handling result before exiting>
 RUN ./test run
@@ -912,6 +936,8 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
 [33m[RUN][0m   3b24997d50c8 [36mmask_pcre_pattern[0m...[2K[32m[PASS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
+[33m[RUN][0m   e8a3ba3cf9b4 [36mmask_temp_paths[0m...[2K[32m[PASS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
 [33m[RUN][0m   d5b0041ea8f4 [36mcheck for substring in stdout[0m...[2K[32m[PASS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
@@ -930,16 +956,16 @@ Legend:
 [33m[RUN][0m   065cc54b852b [36malcotest error formatting[0m...[2K[32m[PASS]  [0m065cc54b852b [36malcotest error formatting[0m
 [2m• [0mChecked output: stderr
 [2m• [0mPath to expected stderr: tests/snapshots/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
+[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
 [33m[RUN][0m   33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m...[2K[32m[PASS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
 [33m[RUN][0m   ec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m...[2K[32m[PASS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/ec7514c8554d/log
 [33m[RUN][0m   b8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m...[2K[32m[PASS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/b8cd199f2e62/log
-21/21 selected tests:
-  20 successful (19 pass, 1 xfail)
+22/22 selected tests:
+  21 successful (20 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m
 <handling result before exiting>
@@ -1007,6 +1033,8 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
 [32m[PASS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
+[32m[PASS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
 [32m[PASS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
@@ -1025,8 +1053,8 @@ Legend:
 [32m[PASS]  [0m065cc54b852b [36malcotest error formatting[0m
 [2m• [0mChecked output: stderr
 [2m• [0mPath to expected stderr: tests/snapshots/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
+[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
 [32m[PASS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
 [32m[PASS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
@@ -1067,8 +1095,8 @@ Legend:
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
 [2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-21/21 selected tests:
-  20 successful (19 pass, 1 xfail)
+22/22 selected tests:
+  21 successful (20 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 4 tests whose output needs first-time approval
 overall status: [31mfailure[0m

--- a/tests/snapshots/testo_tests/065cc54b852b/stderr
+++ b/tests/snapshots/testo_tests/065cc54b852b/stderr
@@ -1,6 +1,6 @@
 ASSERT <description>
 Alcotest assertion failure
-File "tests/Test.ml", line 48, character 6:
+File "tests/Test.ml", line <MASKED>
 FAIL <description>
 
    Expected: `"a"'


### PR DESCRIPTION
The goal is to only mask the variable parts of a temporary path that shows up in the output of a test rather than the whole path.

Common cases are depths of 0 or 1:
* depth = 0: `/tmp/hello` -> `<MASKED>hello`
* depth = 1: `/tmp/hello` -> `<MASKED>`; `/tmp/ab43987f1/hello` -> `<MASKED>hello`

Depth = 1 is now the default which will break existing snapshots. I believe it's the preferred setting most of the time, though. The old behavior was equivalent to masking the whole path i.e. unlimited depth (`~depth:None`).
