### PR TITLE
Improve mask_temp_paths

### DIFF
--- a/core/Testo.mli
+++ b/core/Testo.mli
@@ -294,22 +294,25 @@ val mask_line :
    what the ocaml-re library supports.
 
    In the case that the pattern contains a capturing group and it
-   (the first group) matches, only this substring is replaced by the mask
-   rather than the whole match.
+   (the first group) matches, only this substring is replaced
+   rather than the whole match. The default [replace] function replaces
+   the capture by ["<MASKED>"].
 
    Examples:
 {v
      (* without a capturing group: *)
-     mask_pcre_pattern ~mask:"X" {|<[0-9]+>|} "xxx <42> xxx"
+     mask_pcre_pattern ~replace:(fun _ -> "X") {|<[0-9]+>|} "xxx <42> xxx"
        = "xxx X xxx"
 v}
 {v
      (* with a capturing group: *)
-     mask_pcre_pattern ~mask:"X" {|<([0-9]+)>|} "xxx <42> xxx"
+     mask_pcre_pattern ~replace:(fun _ -> "X") {|<([0-9]+)>|} "xxx <42> xxx"
        = "xxx <X> xxx"
 v}
 *)
-val mask_pcre_pattern : ?mask:string -> string -> (string -> string)
+val mask_pcre_pattern :
+  ?replace:(string -> string) ->
+  string -> (string -> string)
 
 (**
    Mask strings that look like temporary file paths. This is useful in the
@@ -327,15 +330,21 @@ val mask_pcre_pattern : ?mask:string -> string -> (string -> string)
    {- [depth]: maximum number of path segments to mask after [/tmp] or
                equivalent.
                For example, [/tmp/b4ac9882/foo/bar] will become
-               [<TEMPORARY FILE PATH>foo/bar] with the default depth
+               [<TMP>/<MASKED>/foo/bar] with the default depth
                of [Some 1]. With a depth of 2, if would become
-               [<TEMPORARY FILE PATH>bar]}. Use [None] to mask the full
-               path. Use [Some 0] to mask only [/tmp] or equivalent.
-   {- [mask]: replacement string. Defaults to [<TEMPORARY FILE PATH>].}
+               [<TMP>/<MASKED>/<MASKED>/bar]. Use [None] to mask the full
+               path. Use [Some 0] to mask only [/tmp] or equivalent.}
+   {- [replace]: function that determines what to replace the matched path
+               with.}
+   {- [tmpdir]: the path to the temporary folder to use instead of the
+                system default.}
 }
 *)
 val mask_temp_paths :
-  ?depth:int option -> ?mask:string -> unit -> (string -> string)
+  ?depth:int option ->
+  ?replace:(string -> string) ->
+  ?tmpdir:string ->
+  unit -> (string -> string)
 
 (**
    Keep the given substring and mask everything else.

--- a/tests/Meta_test.ml
+++ b/tests/Meta_test.ml
@@ -102,13 +102,15 @@ let test_failing_flow_status () = failing_test_subcommand ~loc:__LOC__ "status"
 (* Meta test suite *)
 (*****************************************************************************)
 
-let delete pat = T.mask_pcre_pattern ~mask:"" pat
+let delete pat = T.mask_pcre_pattern ~replace:(fun _ -> "") pat
 
 let mask_alcotest_output =
   [
     T.mask_line ~mask:"<MASKED RUN ID>" ~after:"This run has ID `" ~before:"'"
       ();
-    T.mask_pcre_pattern ~mask:"<MASKED DURATION>" {|in [0-9]+\.[0-9]+s|};
+    T.mask_pcre_pattern
+      ~replace:(fun _ -> "<MASKED DURATION>")
+      {|in [0-9]+\.[0-9]+s|};
     T.mask_line ~after:"Called from " ();
     T.mask_line ~after:"Re-raised at " ();
     T.mask_line ~after:"Logs saved to " ();


### PR DESCRIPTION
This changes the interface and behavior of `mask_temp_paths` so as to show more details about the masked path. This replaces the `mask` option by a more general `replace` option in both `mask_temp_paths` and `mask_pcre_pattern`.