### PR TITLE
Switch to a compact output by default for the `status` subcommand

### DIFF
--- a/core/Run.mli
+++ b/core/Run.mli
@@ -2,7 +2,11 @@
    Filter and run tests
 *)
 
-type status_output_style = Short | Full
+type status_output_style =
+  | Long_all
+  | Compact_all
+  | Long_important
+  | Compact_important
 
 (* Type alias for Alcotest test cases *)
 type 'unit_promise alcotest_test_case =

--- a/tests/Meta_test.ml
+++ b/tests/Meta_test.ml
@@ -74,13 +74,15 @@ let test_standard_flow () =
   clear_snapshots ~__LOC__ ();
   test_subcommand ~__LOC__ "status" ~expected_exit_code:1;
   test_subcommand ~__LOC__ "run" ~expected_exit_code:1;
+  test_subcommand ~__LOC__ "status --all --long" ~expected_exit_code:1;
   test_subcommand ~__LOC__ "status" ~expected_exit_code:1;
-  test_subcommand ~__LOC__ "status --short" ~expected_exit_code:1;
   test_subcommand ~__LOC__ "approve -s auto-approve";
   test_subcommand ~__LOC__ "status";
   section "Delete statuses but not snapshots";
   clear_status ~__LOC__ ();
-  test_subcommand ~__LOC__ "status" ~expected_exit_code:1;
+  test_subcommand ~__LOC__ "status -v" ~expected_exit_code:1;
+  test_subcommand ~__LOC__ "status -l" ~expected_exit_code:1;
+  test_subcommand ~__LOC__ "status -a" ~expected_exit_code:1;
   test_subcommand ~__LOC__ "run";
   section "Delete snapshots but not statuses";
   clear_snapshots ~__LOC__ ();

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -7,250 +7,27 @@ RUN rm -rf tests/snapshots/testo_tests/0048917873df
 RUN rm -rf tests/snapshots/testo_tests/17ec149855c2
 RUN rm -rf tests/snapshots/testo_tests/02ac0ea4ae90
 RUN ./test status
-Legend:
-[2m• [0m[PASS]: a successful test that was expected to succeed (good);
-[2m• [0m[FAIL]: a failing test that was expected to succeed (needs fixing);
-[2m• [0m[XFAIL]: a failing test that was expected to fail (tolerated failure);
-[2m• [0m[XPASS]: a successful test that was expected to fail (progress?).
-[2m• [0m[MISS]: a test that never ran;
-[2m• [0m[SKIP]: a test that is always skipped but kept around for some reason;
-[2m• [0m[xxxx*]: a new test for which there's no expected output yet.
-  In this case, you should review the test output and run the 'approve'
-  subcommand once you're satisfied with the output.
-
 [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8dbdda48fb87/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8dbdda48fb87/log
 [33m[MISS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d57ac4525684/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d57ac4525684/log
 [33m[MISS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/bd1c5167dc34/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/bd1c5167dc34/log
 [33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/2c57c8917bfb/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/2c57c8917bfb/log
 [33m[MISS]  [0m68358d78cb0b [36munchecked stderr[0m
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/68358d78cb0b/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/68358d78cb0b/log
 [33m[MISS]  [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m
-[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/9c96a5aa8b4b/stdout[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/9c96a5aa8b4b/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/9c96a5aa8b4b/log
 [33m[MISS]  [0m0048917873df [36mauto-approve[0m > [36mcapture stderr[0m
-[2m• [0mChecked output: stderr
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/0048917873df/stderr[0m
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/0048917873df/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/0048917873df/log
 [33m[MISS]  [0m17ec149855c2 [36mauto-approve[0m > [36mcapture stdxxx[0m
-[2m• [0mChecked output: merged stdout and stderr
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/17ec149855c2/stdxxx[0m
-[2m• [0mPath to captured stdxxx: _build/testo/status/testo_tests/17ec149855c2/stdxxx
 [33m[MISS]  [0m02ac0ea4ae90 [36mauto-approve[0m > [36mcapture stdout and stderr[0m
-[2m• [0mChecked output: separate stdout and stderr
-[2m• [0m[31mMissing files containing the expected output: tests/snapshots/testo_tests/02ac0ea4ae90/stdout, tests/snapshots/testo_tests/02ac0ea4ae90/stderr[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
 [33m[MISS]  [0m85349a4a9157 [36mxfail[0m
-[2m• [0mExpected to fail: raises exception on purpose
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/85349a4a9157/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/85349a4a9157/log
-[33m[MISS]  [0me52e279299e9 [36mskipped[0m
-[2m• [0mAlways skipped
 [33m[MISS]  [0m91a3c9030236 [36mchdir[0m
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/91a3c9030236/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/91a3c9030236/log
 [33m[MISS]  [0ma3e1a604f579 [36mmasked[0m
-[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/a3e1a604f579/outcome[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/a3e1a604f579/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
 [33m[MISS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/3b24997d50c8/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
 [33m[MISS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e8a3ba3cf9b4/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
 [33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
-[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d5b0041ea8f4/outcome[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/d5b0041ea8f4/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log [.orig]
 [33m[MISS]  [0m99746f633129 [36mcheck words in stdout[0m
-[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/99746f633129/outcome[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/99746f633129/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log [.orig]
 [33m[MISS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m
-[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/7e7e7c09bfff/outcome[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/7e7e7c09bfff/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log [.orig]
 [33m[MISS]  [0m065cc54b852b [36malcotest error formatting[0m
-[2m• [0mChecked output: stderr
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/065cc54b852b/outcome[0m
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
 [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/33a93d234d01/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
 [33m[MISS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/ec7514c8554d/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/ec7514c8554d/log
 [33m[MISS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b8cd199f2e62/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/b8cd199f2e62/log
-
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m                                                  [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8dbdda48fb87/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8dbdda48fb87/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m                                     [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d57ac4525684/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d57ac4525684/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m                       [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/bd1c5167dc34/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/bd1c5167dc34/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m                                        [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/2c57c8917bfb/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/2c57c8917bfb/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m68358d78cb0b [36munchecked stderr[0m                                        [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/68358d78cb0b/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/68358d78cb0b/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m                           [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/9c96a5aa8b4b/stdout[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/9c96a5aa8b4b/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/9c96a5aa8b4b/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m0048917873df [36mauto-approve[0m > [36mcapture stderr[0m                           [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stderr
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/0048917873df/stderr[0m
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/0048917873df/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/0048917873df/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m17ec149855c2 [36mauto-approve[0m > [36mcapture stdxxx[0m                           [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: merged stdout and stderr
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/17ec149855c2/stdxxx[0m
-[2m• [0mPath to captured stdxxx: _build/testo/status/testo_tests/17ec149855c2/stdxxx
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m02ac0ea4ae90 [36mauto-approve[0m > [36mcapture stdout and stderr[0m                [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: separate stdout and stderr
-[2m• [0m[31mMissing files containing the expected output: tests/snapshots/testo_tests/02ac0ea4ae90/stdout, tests/snapshots/testo_tests/02ac0ea4ae90/stderr[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m85349a4a9157 [36mxfail[0m                                                   [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mExpected to fail: raises exception on purpose
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/85349a4a9157/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/85349a4a9157/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m91a3c9030236 [36mchdir[0m                                                   [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/91a3c9030236/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/91a3c9030236/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0ma3e1a604f579 [36mmasked[0m                                                  [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/a3e1a604f579/outcome[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/a3e1a604f579/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m                                       [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/3b24997d50c8/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m                                         [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e8a3ba3cf9b4/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m                           [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d5b0041ea8f4/outcome[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/d5b0041ea8f4/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log [.orig]
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m99746f633129 [36mcheck words in stdout[0m                                   [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/99746f633129/outcome[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/99746f633129/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log [.orig]
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m                          [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/7e7e7c09bfff/outcome[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/7e7e7c09bfff/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log [.orig]
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m065cc54b852b [36malcotest error formatting[0m                               [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stderr
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/065cc54b852b/outcome[0m
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m                               [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/33a93d234d01/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m                                [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/ec7514c8554d/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/ec7514c8554d/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m                        [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b8cd199f2e62/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/b8cd199f2e62/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-22/22 selected tests:
-  0 successful (0 pass, 0 xfail)
-  0 unsuccessful (0 fail, 0 xpass)
-21 new tests
-overall status: [31mfailure[0m
 <handling result before exiting>
 RUN ./test run
 Legend:
@@ -374,7 +151,7 @@ Legend:
 4 tests whose output needs first-time approval
 overall status: [31mfailure[0m
 <handling result before exiting>
-RUN ./test status
+RUN ./test status --all --long
 Legend:
 [2m• [0m[PASS]: a successful test that was expected to succeed (good);
 [2m• [0m[FAIL]: a failing test that was expected to succeed (needs fixing);
@@ -499,144 +276,22 @@ Legend:
 4 tests whose output needs first-time approval
 overall status: [31mfailure[0m
 <handling result before exiting>
-RUN ./test status --short
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[PASS*] [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m                           [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/9c96a5aa8b4b/stdout[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/9c96a5aa8b4b/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/9c96a5aa8b4b/log
-[2m• [0mLog (stderr) is empty.
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[PASS*] [0m0048917873df [36mauto-approve[0m > [36mcapture stderr[0m                           [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stderr
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/0048917873df/stderr[0m
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/0048917873df/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/0048917873df/log
-[2m• [0mLog (stdout) is empty.
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[PASS*] [0m17ec149855c2 [36mauto-approve[0m > [36mcapture stdxxx[0m                           [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: merged stdout and stderr
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/17ec149855c2/stdxxx[0m
-[2m• [0mPath to captured stdxxx: _build/testo/status/testo_tests/17ec149855c2/stdxxx
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[PASS*] [0m02ac0ea4ae90 [36mauto-approve[0m > [36mcapture stdout and stderr[0m                [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: separate stdout and stderr
-[2m• [0m[31mMissing files containing the expected output: tests/snapshots/testo_tests/02ac0ea4ae90/stdout, tests/snapshots/testo_tests/02ac0ea4ae90/stderr[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-22/22 selected tests:
-  21 successful (20 pass, 1 xfail)
-  0 unsuccessful (0 fail, 0 xpass)
-4 tests whose output needs first-time approval
-overall status: [31mfailure[0m
+RUN ./test status
+[33m[PASS*] [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m
+[33m[PASS*] [0m0048917873df [36mauto-approve[0m > [36mcapture stderr[0m
+[33m[PASS*] [0m17ec149855c2 [36mauto-approve[0m > [36mcapture stdxxx[0m
+[33m[PASS*] [0m02ac0ea4ae90 [36mauto-approve[0m > [36mcapture stdout and stderr[0m
 <handling result before exiting>
 RUN ./test approve -s auto-approve
 Expected output changed for 4 tests.
 <handling result before exiting>
 RUN ./test status
-Legend:
-[2m• [0m[PASS]: a successful test that was expected to succeed (good);
-[2m• [0m[FAIL]: a failing test that was expected to succeed (needs fixing);
-[2m• [0m[XFAIL]: a failing test that was expected to fail (tolerated failure);
-[2m• [0m[XPASS]: a successful test that was expected to fail (progress?).
-[2m• [0m[MISS]: a test that never ran;
-[2m• [0m[SKIP]: a test that is always skipped but kept around for some reason;
-[2m• [0m[xxxx*]: a new test for which there's no expected output yet.
-  In this case, you should review the test output and run the 'approve'
-  subcommand once you're satisfied with the output.
-
-[32m[PASS]  [0m8dbdda48fb87 [36msimple[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8dbdda48fb87/log
-[32m[PASS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d57ac4525684/log
-[32m[PASS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/bd1c5167dc34/log
-[32m[PASS]  [0m2c57c8917bfb [36munchecked stdout[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/2c57c8917bfb/log
-[32m[PASS]  [0m68358d78cb0b [36munchecked stderr[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/68358d78cb0b/log
-[32m[PASS]  [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected stdout: tests/snapshots/testo_tests/9c96a5aa8b4b/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/9c96a5aa8b4b/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/9c96a5aa8b4b/log
-[32m[PASS]  [0m0048917873df [36mauto-approve[0m > [36mcapture stderr[0m
-[2m• [0mChecked output: stderr
-[2m• [0mPath to expected stderr: tests/snapshots/testo_tests/0048917873df/stderr
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/0048917873df/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/0048917873df/log
-[32m[PASS]  [0m17ec149855c2 [36mauto-approve[0m > [36mcapture stdxxx[0m
-[2m• [0mChecked output: merged stdout and stderr
-[2m• [0mPath to expected stdxxx: tests/snapshots/testo_tests/17ec149855c2/stdxxx
-[2m• [0mPath to captured stdxxx: _build/testo/status/testo_tests/17ec149855c2/stdxxx
-[32m[PASS]  [0m02ac0ea4ae90 [36mauto-approve[0m > [36mcapture stdout and stderr[0m
-[2m• [0mChecked output: separate stdout and stderr
-[2m• [0mPath to expected stdout: tests/snapshots/testo_tests/02ac0ea4ae90/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
-[2m• [0mPath to expected stderr: tests/snapshots/testo_tests/02ac0ea4ae90/stderr
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
-[32m[XFAIL] [0m85349a4a9157 [36mxfail[0m
-[2m• [0mExpected to fail: raises exception on purpose
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/85349a4a9157/log
-[33m[MISS]  [0me52e279299e9 [36mskipped[0m
-[2m• [0mAlways skipped
-[32m[PASS]  [0m91a3c9030236 [36mchdir[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/91a3c9030236/log
-[32m[PASS]  [0ma3e1a604f579 [36mmasked[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected stdout: tests/snapshots/testo_tests/a3e1a604f579/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/a3e1a604f579/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
-[32m[PASS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
-[32m[PASS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
-[32m[PASS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/d5b0041ea8f4/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log [.orig]
-[32m[PASS]  [0m99746f633129 [36mcheck words in stdout[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected stdout: tests/snapshots/testo_tests/99746f633129/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/99746f633129/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log [.orig]
-[32m[PASS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected stdout: tests/snapshots/testo_tests/7e7e7c09bfff/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/7e7e7c09bfff/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log [.orig]
-[32m[PASS]  [0m065cc54b852b [36malcotest error formatting[0m
-[2m• [0mChecked output: stderr
-[2m• [0mPath to expected stderr: tests/snapshots/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
-[32m[PASS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
-[32m[PASS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/ec7514c8554d/log
-[32m[PASS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/b8cd199f2e62/log
-
-22/22 selected tests:
-  21 successful (20 pass, 1 xfail)
-  0 unsuccessful (0 fail, 0 xpass)
-overall status: [32msuccess[0m
 <handling result before exiting>
 #####################################################################
 # Delete statuses but not snapshots
 #####################################################################
 RUN rm -rf _build/testo/status/testo_tests
-RUN ./test status
+RUN ./test status -v
 Legend:
 [2m• [0m[PASS]: a successful test that was expected to succeed (good);
 [2m• [0m[FAIL]: a failing test that was expected to succeed (needs fixing);
@@ -882,6 +537,181 @@ Legend:
 21 new tests
 overall status: [31mfailure[0m
 <handling result before exiting>
+RUN ./test status -l
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m                                                  [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8dbdda48fb87/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/8dbdda48fb87/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m                                     [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d57ac4525684/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/d57ac4525684/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/bd1c5167dc34/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/bd1c5167dc34/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/2c57c8917bfb/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/2c57c8917bfb/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m68358d78cb0b [36munchecked stderr[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/68358d78cb0b/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/68358d78cb0b/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m                           [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mChecked output: stdout
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/9c96a5aa8b4b/outcome[0m
+[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/9c96a5aa8b4b/stdout
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/9c96a5aa8b4b/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m0048917873df [36mauto-approve[0m > [36mcapture stderr[0m                           [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mChecked output: stderr
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/0048917873df/outcome[0m
+[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/0048917873df/stderr
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/0048917873df/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m17ec149855c2 [36mauto-approve[0m > [36mcapture stdxxx[0m                           [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mChecked output: merged stdout and stderr
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/17ec149855c2/outcome[0m
+[2m• [0mPath to captured stdxxx: _build/testo/status/testo_tests/17ec149855c2/stdxxx
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m02ac0ea4ae90 [36mauto-approve[0m > [36mcapture stdout and stderr[0m                [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mChecked output: separate stdout and stderr
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/02ac0ea4ae90/outcome[0m
+[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
+[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m85349a4a9157 [36mxfail[0m                                                   [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mExpected to fail: raises exception on purpose
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/85349a4a9157/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/85349a4a9157/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m91a3c9030236 [36mchdir[0m                                                   [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/91a3c9030236/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/91a3c9030236/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0ma3e1a604f579 [36mmasked[0m                                                  [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mChecked output: stdout
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/a3e1a604f579/outcome[0m
+[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/a3e1a604f579/stdout [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/3b24997d50c8/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m                                         [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e8a3ba3cf9b4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m                           [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mChecked output: stdout
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d5b0041ea8f4/outcome[0m
+[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/d5b0041ea8f4/stdout [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log [.orig]
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m99746f633129 [36mcheck words in stdout[0m                                   [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mChecked output: stdout
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/99746f633129/outcome[0m
+[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/99746f633129/stdout [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log [.orig]
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m                          [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mChecked output: stdout
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/7e7e7c09bfff/outcome[0m
+[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/7e7e7c09bfff/stdout [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log [.orig]
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m065cc54b852b [36malcotest error formatting[0m                               [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mChecked output: stderr
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/065cc54b852b/outcome[0m
+[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m                               [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/33a93d234d01/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m                                [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/ec7514c8554d/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/ec7514c8554d/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b8cd199f2e62/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b8cd199f2e62/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+22/22 selected tests:
+  0 successful (0 pass, 0 xfail)
+  0 unsuccessful (0 fail, 0 xpass)
+21 new tests
+overall status: [31mfailure[0m
+<handling result before exiting>
+RUN ./test status -a
+[33m[MISS]  [0m8dbdda48fb87 [36msimple[0m
+[33m[MISS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
+[33m[MISS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
+[33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m
+[33m[MISS]  [0m68358d78cb0b [36munchecked stderr[0m
+[33m[MISS]  [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m
+[33m[MISS]  [0m0048917873df [36mauto-approve[0m > [36mcapture stderr[0m
+[33m[MISS]  [0m17ec149855c2 [36mauto-approve[0m > [36mcapture stdxxx[0m
+[33m[MISS]  [0m02ac0ea4ae90 [36mauto-approve[0m > [36mcapture stdout and stderr[0m
+[33m[MISS]  [0m85349a4a9157 [36mxfail[0m
+[33m[MISS]  [0me52e279299e9 [36mskipped[0m
+[33m[MISS]  [0m91a3c9030236 [36mchdir[0m
+[33m[MISS]  [0ma3e1a604f579 [36mmasked[0m
+[33m[MISS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
+[33m[MISS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
+[33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
+[33m[MISS]  [0m99746f633129 [36mcheck words in stdout[0m
+[33m[MISS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m
+[33m[MISS]  [0m065cc54b852b [36malcotest error formatting[0m
+[33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
+[33m[MISS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
+[33m[MISS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m
+<handling result before exiting>
 RUN ./test run
 Legend:
 [2m• [0m[PASS]: a successful test that was expected to succeed (good);
@@ -977,129 +807,10 @@ RUN rm -rf tests/snapshots/testo_tests/0048917873df
 RUN rm -rf tests/snapshots/testo_tests/17ec149855c2
 RUN rm -rf tests/snapshots/testo_tests/02ac0ea4ae90
 RUN ./test status
-Legend:
-[2m• [0m[PASS]: a successful test that was expected to succeed (good);
-[2m• [0m[FAIL]: a failing test that was expected to succeed (needs fixing);
-[2m• [0m[XFAIL]: a failing test that was expected to fail (tolerated failure);
-[2m• [0m[XPASS]: a successful test that was expected to fail (progress?).
-[2m• [0m[MISS]: a test that never ran;
-[2m• [0m[SKIP]: a test that is always skipped but kept around for some reason;
-[2m• [0m[xxxx*]: a new test for which there's no expected output yet.
-  In this case, you should review the test output and run the 'approve'
-  subcommand once you're satisfied with the output.
-
-[32m[PASS]  [0m8dbdda48fb87 [36msimple[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8dbdda48fb87/log
-[32m[PASS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d57ac4525684/log
-[32m[PASS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/bd1c5167dc34/log
-[32m[PASS]  [0m2c57c8917bfb [36munchecked stdout[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/2c57c8917bfb/log
-[32m[PASS]  [0m68358d78cb0b [36munchecked stderr[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/68358d78cb0b/log
 [33m[PASS*] [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m
-[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/9c96a5aa8b4b/stdout[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/9c96a5aa8b4b/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/9c96a5aa8b4b/log
-[2m• [0mLog (stderr) is empty.
 [33m[PASS*] [0m0048917873df [36mauto-approve[0m > [36mcapture stderr[0m
-[2m• [0mChecked output: stderr
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/0048917873df/stderr[0m
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/0048917873df/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/0048917873df/log
-[2m• [0mLog (stdout) is empty.
 [33m[PASS*] [0m17ec149855c2 [36mauto-approve[0m > [36mcapture stdxxx[0m
-[2m• [0mChecked output: merged stdout and stderr
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/17ec149855c2/stdxxx[0m
-[2m• [0mPath to captured stdxxx: _build/testo/status/testo_tests/17ec149855c2/stdxxx
 [33m[PASS*] [0m02ac0ea4ae90 [36mauto-approve[0m > [36mcapture stdout and stderr[0m
-[2m• [0mChecked output: separate stdout and stderr
-[2m• [0m[31mMissing files containing the expected output: tests/snapshots/testo_tests/02ac0ea4ae90/stdout, tests/snapshots/testo_tests/02ac0ea4ae90/stderr[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
-[32m[XFAIL] [0m85349a4a9157 [36mxfail[0m
-[2m• [0mExpected to fail: raises exception on purpose
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/85349a4a9157/log
-[33m[MISS]  [0me52e279299e9 [36mskipped[0m
-[2m• [0mAlways skipped
-[32m[PASS]  [0m91a3c9030236 [36mchdir[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/91a3c9030236/log
-[32m[PASS]  [0ma3e1a604f579 [36mmasked[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected stdout: tests/snapshots/testo_tests/a3e1a604f579/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/a3e1a604f579/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
-[32m[PASS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
-[32m[PASS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
-[32m[PASS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/d5b0041ea8f4/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log [.orig]
-[32m[PASS]  [0m99746f633129 [36mcheck words in stdout[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected stdout: tests/snapshots/testo_tests/99746f633129/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/99746f633129/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log [.orig]
-[32m[PASS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected stdout: tests/snapshots/testo_tests/7e7e7c09bfff/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/7e7e7c09bfff/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log [.orig]
-[32m[PASS]  [0m065cc54b852b [36malcotest error formatting[0m
-[2m• [0mChecked output: stderr
-[2m• [0mPath to expected stderr: tests/snapshots/testo_tests/065cc54b852b/stderr
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
-[32m[PASS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
-[32m[PASS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/ec7514c8554d/log
-[32m[PASS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/b8cd199f2e62/log
-
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[PASS*] [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m                           [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/9c96a5aa8b4b/stdout[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/9c96a5aa8b4b/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/9c96a5aa8b4b/log
-[2m• [0mLog (stderr) is empty.
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[PASS*] [0m0048917873df [36mauto-approve[0m > [36mcapture stderr[0m                           [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stderr
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/0048917873df/stderr[0m
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/0048917873df/stderr
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/0048917873df/log
-[2m• [0mLog (stdout) is empty.
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[PASS*] [0m17ec149855c2 [36mauto-approve[0m > [36mcapture stdxxx[0m                           [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: merged stdout and stderr
-[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/17ec149855c2/stdxxx[0m
-[2m• [0mPath to captured stdxxx: _build/testo/status/testo_tests/17ec149855c2/stdxxx
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[PASS*] [0m02ac0ea4ae90 [36mauto-approve[0m > [36mcapture stdout and stderr[0m                [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: separate stdout and stderr
-[2m• [0m[31mMissing files containing the expected output: tests/snapshots/testo_tests/02ac0ea4ae90/stdout, tests/snapshots/testo_tests/02ac0ea4ae90/stderr[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
-[2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-22/22 selected tests:
-  21 successful (20 pass, 1 xfail)
-  0 unsuccessful (0 fail, 0 xpass)
-4 tests whose output needs first-time approval
-overall status: [31mfailure[0m
 <handling result before exiting>
 RUN ./test approve -s auto-approve
 Expected output changed for 4 tests.


### PR DESCRIPTION
The `--short` option is gone and its behavior is now the default which is to print only the tests that need attention, omitting the tests that were successful or skipped. `--all`/`-a` prints all the tests like before. The default output now consists of one line per test. `--long`/`-l` prints tests in the long format like before.

The options `-l` and `-a` were chosen to remind us of the same familiar options of the `ls` command.

This is not quite an interactive test browser (https://github.com/semgrep/testo/issues/39) but it was easy to implement.