### PR TITLE
Backward compatibility with ocaml 4.08

### DIFF
--- a/.circleci/setup
+++ b/.circleci/setup
@@ -7,4 +7,8 @@ set -eu
 
 eval "$(opam env)"
 opam update
-opam install -y ./testo.opam ./testo-lwt.opam
+
+# This should not install 'testo' even though it's a dependency of 'testo-lwt'.
+opam install --deps-only -y \
+  ./testo.opam \
+  ./testo-lwt.opam

--- a/core/Helpers.ml
+++ b/core/Helpers.ml
@@ -35,8 +35,8 @@ let rec make_dir_if_not_exists ?(recursive = false) dir =
              dir)
       else if recursive then (
         make_dir_if_not_exists ~recursive parent;
-        Sys.mkdir dir 0o777)
-      else if Sys.file_exists parent then Sys.mkdir dir 0o777
+        Unix.mkdir dir 0o777)
+      else if Sys.file_exists parent then Unix.mkdir dir 0o777
       else
         failwith
           (sprintf "The parent folder of %S doesn't exist (current folder: %S)"

--- a/core/Run.ml
+++ b/core/Run.ml
@@ -410,6 +410,12 @@ let with_highlight_test ~highlight_test ~title func =
   func ();
   if highlight_test then print_string (Style.horizontal_line ())
 
+let ends_with_newline str =
+  (* not available in ocaml 4.08:
+     String.ends_with ~suffix:"\n" str
+  *)
+  str <> "" && str.[String.length str - 1] = '\n'
+
 let print_status ~highlight_test ~always_show_unchecked_output
     (((test : _ T.test), (status : T.status), sum) as test_with_status)=
   let title = format_one_line_status test_with_status in
@@ -489,7 +495,7 @@ let print_status ~highlight_test ~always_show_unchecked_output
               | _ ->
                   printf "%sLog (%s):\n%s" bullet log_description
                     (Style.quote_multiline_text data);
-                  if not (String.ends_with ~suffix:"\n" data) then
+                  if not (ends_with_newline data) then
                     print_char '\n'
         )));
   flush stdout

--- a/tests/Test.ml
+++ b/tests/Test.ml
@@ -159,8 +159,14 @@ let tests =
       );
     t "alcotest error formatting"
       ~checked_output:Stderr
-      ~normalize:[Testo.mask_line ~after:{|File "tests/Test.ml", line |} ()]
-      test_alcotest_error_formatting
+      ~normalize:[
+        (* In our CI environment for ocaml 4.08, the line
+           "File "tests/Test.ml", line ..." is missing, so we mask it if
+           it exists. *)
+        Testo.mask_pcre_pattern
+          "Alcotest assertion failure((?:\nFile [^\n]*)?)\n"
+      ]
+      test_alcotest_error_formatting;
   ] @ categorized
 
 let () =

--- a/tests/snapshots/testo_tests/065cc54b852b/stderr
+++ b/tests/snapshots/testo_tests/065cc54b852b/stderr
@@ -1,6 +1,5 @@
 ASSERT <description>
-Alcotest assertion failure
-File "tests/Test.ml", line <MASKED>
+Alcotest assertion failure<MASKED>
 FAIL <description>
 
    Expected: `"a"'


### PR DESCRIPTION
This includes all the necessary fixes for CI checks to work correctly with ocaml 4.08 in addition to the ocaml 4.14 (TODO: update https://github.com/mjambon/ocaml-layer to provide an image for ocaml 5).