### PR TITLE
Fix 'mask_temp_paths' for when the temp folder path ends with a slash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 0.1.0 (YYYY-MM-DD)
 ------------------
 
+<!-- No need to add changelog items for our first release. -->
 * First official release

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,4 @@
 0.1.0 (YYYY-MM-DD)
 ------------------
 
-* ...
-
+* First official release

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -21,6 +21,7 @@ RUN ./test status
 [33m[MISS]  [0ma3e1a604f579 [36mmasked[0m
 [33m[MISS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [33m[MISS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
+[33m[MISS]  [0mcb1a0033f274 [36mmask exotic temp paths[0m
 [33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [33m[MISS]  [0m99746f633129 [36mcheck words in stdout[0m
 [33m[MISS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m
@@ -86,6 +87,8 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
 [33m[RUN][0m   e8a3ba3cf9b4 [36mmask_temp_paths[0m...[2K[32m[PASS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
+[33m[RUN][0m   cb1a0033f274 [36mmask exotic temp paths[0m...[2K[32m[PASS]  [0mcb1a0033f274 [36mmask exotic temp paths[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/cb1a0033f274/log
 [33m[RUN][0m   d5b0041ea8f4 [36mcheck for substring in stdout[0m...[2K[32m[PASS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
@@ -145,8 +148,8 @@ Legend:
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
 [2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-22/22 selected tests:
-  21 successful (20 pass, 1 xfail)
+23/23 selected tests:
+  22 successful (21 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 4 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -210,6 +213,8 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
 [32m[PASS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
+[32m[PASS]  [0mcb1a0033f274 [36mmask exotic temp paths[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/cb1a0033f274/log
 [32m[PASS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
@@ -270,8 +275,8 @@ Legend:
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/02ac0ea4ae90/stdout
 [2m• [0mPath to captured stderr: _build/testo/status/testo_tests/02ac0ea4ae90/stderr
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-22/22 selected tests:
-  21 successful (20 pass, 1 xfail)
+23/23 selected tests:
+  22 successful (21 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 4 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -357,6 +362,9 @@ Legend:
 [33m[MISS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e8a3ba3cf9b4/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
+[33m[MISS]  [0mcb1a0033f274 [36mmask exotic temp paths[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/cb1a0033f274/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/cb1a0033f274/log
 [33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d5b0041ea8f4/outcome[0m
@@ -482,6 +490,12 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mcb1a0033f274 [36mmask exotic temp paths[0m                                  [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/cb1a0033f274/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/cb1a0033f274/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m                           [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
@@ -531,10 +545,10 @@ Legend:
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b8cd199f2e62/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/b8cd199f2e62/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-22/22 selected tests:
+23/23 selected tests:
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-21 new tests
+22 new tests
 overall status: [31mfailure[0m
 <handling result before exiting>
 RUN ./test status -l
@@ -633,6 +647,12 @@ RUN ./test status -l
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mcb1a0033f274 [36mmask exotic temp paths[0m                                  [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/cb1a0033f274/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/cb1a0033f274/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m                           [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
@@ -682,10 +702,10 @@ RUN ./test status -l
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b8cd199f2e62/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/b8cd199f2e62/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-22/22 selected tests:
+23/23 selected tests:
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-21 new tests
+22 new tests
 overall status: [31mfailure[0m
 <handling result before exiting>
 RUN ./test status -a
@@ -704,6 +724,7 @@ RUN ./test status -a
 [33m[MISS]  [0ma3e1a604f579 [36mmasked[0m
 [33m[MISS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [33m[MISS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
+[33m[MISS]  [0mcb1a0033f274 [36mmask exotic temp paths[0m
 [33m[MISS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [33m[MISS]  [0m99746f633129 [36mcheck words in stdout[0m
 [33m[MISS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m
@@ -768,6 +789,8 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
 [33m[RUN][0m   e8a3ba3cf9b4 [36mmask_temp_paths[0m...[2K[32m[PASS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/e8a3ba3cf9b4/log
+[33m[RUN][0m   cb1a0033f274 [36mmask exotic temp paths[0m...[2K[32m[PASS]  [0mcb1a0033f274 [36mmask exotic temp paths[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/cb1a0033f274/log
 [33m[RUN][0m   d5b0041ea8f4 [36mcheck for substring in stdout[0m...[2K[32m[PASS]  [0md5b0041ea8f4 [36mcheck for substring in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
@@ -794,8 +817,8 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/ec7514c8554d/log
 [33m[RUN][0m   b8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m...[2K[32m[PASS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/b8cd199f2e62/log
-22/22 selected tests:
-  21 successful (20 pass, 1 xfail)
+23/23 selected tests:
+  22 successful (21 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m
 <handling result before exiting>


### PR DESCRIPTION
(or backslash on Windows).

This a partial redo of https://github.com/semgrep/testo/pull/42

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
