### PR TITLE
Fix mask_temp_paths to handle symlinks

### DIFF
--- a/core/Testo.ml
+++ b/core/Testo.ml
@@ -287,7 +287,8 @@ let mask_temp_paths
     if tmpdir = "" then
       Error.invalid_arg ~__LOC__ "Testo.mask_temp_paths: empty tmpdir"
     else
-      remove_trailing_slashes tmpdir
+      (* Must resolve symlinks via 'Unix.realpath'. *)
+      remove_trailing_slashes tmpdir |> Unix.realpath
   in
   let tmpdir_pat = Re.Pcre.quote tmpdir in
   let suffix_pat =


### PR DESCRIPTION
If `tmpdir` is not a realpath, i.e. contains symlinks, 'mask_temp_paths' will not work as expected.

test plan:
See semgrep/semgrep#10077

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
