### PR TITLE
Don't mask temporary paths that occur as substrings of other paths

### DIFF
--- a/core/Testo.ml
+++ b/core/Testo.ml
@@ -317,7 +317,7 @@ let mask_temp_paths
          pattern to ensure we don't start the match in a middle of a path. *)
       sprintf {|(?:^|%s)|} nonpath_character
     in
-    (* The captured group in parentheses what will get replaced by the
+    (* The captured group in parentheses is what will get replaced by the
        'replace' function. It's a full path. *)
     sprintf "%s(%s%s)"
       not_preceded_by_a_path_character tmpdir_pat suffix_pat

--- a/core/Testo.ml
+++ b/core/Testo.ml
@@ -5,6 +5,7 @@
    Alcotest.
 *)
 
+open Printf
 module T = Types
 
 (****************************************************************************)
@@ -278,6 +279,10 @@ let rec remove_trailing_slashes path =
   else
     path
 
+let path_character_range = {|/\\:A-Za-z0-9_.-|}
+let path_character = "[" ^ path_character_range ^ "]"
+let nonpath_character = "[^" ^ path_character_range ^ "]"
+
 let mask_temp_paths
     ?(depth = Some 1)
     ?replace
@@ -293,7 +298,7 @@ let mask_temp_paths
   let suffix_pat =
     match depth with
     | None ->
-        {|[/\\A-Za-z0-9_.-]*|}
+        sprintf {|%s*|} path_character
     | Some n ->
         if n < 0 then
           Error.invalid_arg ~__LOC__
@@ -306,7 +311,17 @@ let mask_temp_paths
           in
           repeat (sep ^ segment)
   in
-  let pat = tmpdir_pat ^ suffix_pat in
+  let pat =
+    let not_preceded_by_a_path_character =
+      (* ocaml-re doesn't support lookbehind assertions so we match this
+         pattern to ensure we don't start the match in a middle of a path. *)
+      sprintf {|(?:^|%s)|} nonpath_character
+    in
+    (* The captured group in parentheses what will get replaced by the
+       'replace' function. It's a full path. *)
+    sprintf "%s(%s%s)"
+      not_preceded_by_a_path_character tmpdir_pat suffix_pat
+  in
   let replace =
     match replace with
     | None -> default_replace_path ~tmpdir

--- a/tests/Test.ml
+++ b/tests/Test.ml
@@ -43,7 +43,8 @@ let test_mask_pcre_pattern () =
 
 (* TODO: test Windows paths *)
 let test_mask_temp_paths () =
-  let tmpdir = "tmpdir" in
+  let tmpdir = "/tmp" in
+  let includes_tmpdir = "/var/tmp/1234" in
   let test_one (depth, input_str, expected_result) =
     printf "depth=%S input_str=%S expected_result=%S\n%!"
       (match depth with
@@ -66,6 +67,8 @@ let test_mask_temp_paths () =
     None, tmp "a-b_12/bcccc", "<TMP>/<MASKED>/bcccc";
     None, " " ^ tmp "a-b_12//bcccc/// ", " <TMP>/<MASKED>//bcccc/// ";
     None, tmp "a" ^ " " ^ tmp "b", "<TMP>/<MASKED> <TMP>/<MASKED>";
+    (* don't mask sub-paths *)
+    None, includes_tmpdir, includes_tmpdir;
     (* no depth limit *)
     Some None, tmpdir, "<TMP>";
     Some None, tmp "", "<TMP>/";


### PR DESCRIPTION
Fixes #55 

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
