### PR TITLE
Add a tutorial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@
 
 version: 2.1
 
+# TODO: check that the docs are up-to-date (requires odoc and pandoc)
 jobs:
   build:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ retest: build
 .PHONY: doc
 doc:
 	$(MAKE) -C docsrc
+	$(MAKE) -C docsrc test
 
 .PHONY: clean
 clean:

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
 </header>
 <p>Testo is a test framework for OCaml.</p>
 <ul>
-<li>🚧 <a href="tutorial">Tutorial</a></li>
+<li><a href="tutorial">Tutorial</a></li>
 <li>🚧 <a href="howtos">Howtos</a></li>
 <li><a href="reference/testo/Testo/">Reference</a></li>
 </ul>

--- a/docs/tutorial/index.html
+++ b/docs/tutorial/index.html
@@ -17,6 +17,194 @@
 <header id="title-block-header">
 <h1 class="title">Testo tutorial</h1>
 </header>
-<p>Coming soon!</p>
+<h2 id="introduction">Introduction</h2>
+<p>Testo is a test framework for OCaml. Like with OUnit or Alcotest, the user writes a collection of tests. A test consists of a name and an OCaml test function to run, with some options. If the test function returns, the test is considered successful but if it raises an exception, it is considered failed.</p>
+<p>The test suite is compiled into a test executable with a fancy command-line interface provided by the Testo library.</p>
+<h2 id="main-features">Main features</h2>
+<ul>
+<li>Most tests can be defined by providing only a name and a function of type <code>unit -&gt; unit</code>.</li>
+<li>Tests can be assigned nested categories of arbitrary depth but are conveniently handled as a single flat list.</li>
+<li>Tests that are expected to fail (“XFAIL”) can be marked as such. This allows writing tests ahead of feature implementation or bug fixes.</li>
+<li>Supports output snapshots, i.e. capturing stdout or stderr from a test and comparing it with a reference file.</li>
+<li>Reviewing previous test outcomes can done without rerunning the tests.</li>
+<li>Provides various utilities for capturing stdout or stderr, and masking variable parts of test output such as temporary file paths.</li>
+<li>Support for tests that return Lwt promises.</li>
+</ul>
+<p>XFAIL outcomes and snapshot files are two features borrowed from Pytest that would have required massive changes in Alcotest and led to the creation of a new project.</p>
+<h2 id="should-i-use-testo">Should I use Testo?</h2>
+<p>Testo was designed to support older OCaml versions starting from 4.08 and to be maintained by the community of users. It is being used to test <a href="https://github.com/semgrep/semgrep">Semgrep</a> which has about 5000 OCaml tests, most of which were originally migrated from Alcotest. Check out the <a href="https://github.com/semgrep/testo/issues">known missing features</a> to see if anything critical to you is missing.</p>
+<h2 id="getting-started">Getting started</h2>
+<h3 id="install-the-testo-library">Install the <code>testo</code> library</h3>
+<p>🚧 <del>Install <code>testo</code> with Opam using <code>opam install testo</code></del> For now, we recommend using <code>testo</code> as a git submodule. Dune will pick it up and build it as part of your project like an ordinary library.</p>
+<h3 id="set-up-your-project">Set up your project</h3>
+<p>The folder <code>tests/snapshots/</code> will be used by Testo to store test snapshots to be tracked by your favorite version control system (git, …). Storing other test data under <code>tests/</code> is encouraged as long as you let Testo manage <code>tests/snapshots/</code>.</p>
+<h3 id="write-a-test-executable">Write a test executable</h3>
+<p>The test executable can be placed anywhere in your Dune project. We recommend having only one such program if possible and calling it <code>test</code>. In this tutorial, we’ll put it in the <code>tests/</code> folder.</p>
+<p>We are going to create the following folders and files:</p>
+<ul>
+<li><code>tests/Test.ml</code>: the entry point of the <code>test</code> program</li>
+<li><code>tests/dune</code>: the Dune file that defines how to build the test executable</li>
+<li><code>tests/snapshots/</code>: created and managed by Testo, under version control</li>
+<li><code>test</code>: a symbolic link to <code>_build/default/tests/test.exe</code></li>
+</ul>
+<p>Create the following <code>tests/dune</code> whose job is to build an ordinary executable named <code>test</code>:</p>
+<pre><code>; Build the test executable for our project
+(executable
+ (name test)
+ (modules Test)
+ (libraries
+    testo
+ )
+)</code></pre>
+<p>We recommend running the test program always from the project root so as to reference any files using paths relative to the project root. Create the symbolic link that will allow us to call the test program directly from the project root:</p>
+<pre><code>$ ln -s _build/default/tests/test.exe test</code></pre>
+<p>If you already have a <code>test</code> file or folder, you may pick another name for the Testo program, it doesn’t matter. The examples in this tutorial assume <code>./test</code> calls our Testo-based test program.</p>
+<p>The last part of this setup is to write the OCaml file <code>tests/Test.ml</code>. Let’s use this:</p>
+<pre><code>(*
+   The entry point for the &#39;test&#39; program that runs the suite of OCaml
+   tests for &lt;this project&gt;.
+*)
+
+let test_hello =
+  Testo.create &quot;hello&quot;
+    (fun () -&gt; print_endline &quot;hello!&quot;)
+
+let tests = [
+  test_hello;
+]
+
+let () =
+  Testo.interpret_argv
+    ~project_name:&quot;my_project&quot;
+    (fun () -&gt; tests)</code></pre>
+<h3 id="check-your-setup">Check your setup</h3>
+<p>From the project root, build your project as usual with Dune:</p>
+<pre><code>$ dune build</code></pre>
+<p>If everything went according to plan, running the test program with <code>--help</code> will list the subcommands supported by <code>./test</code>:</p>
+<pre><code>$ ./test --help
+TEST(1)                           Test Manual                          TEST(1)
+
+
+
+NAME
+       test - run tests for my_project
+
+SYNOPSIS
+       test [COMMAND] …
+
+DESCRIPTION
+
+...
+
+COMMANDS
+       approve [--filter-substring=SUBSTRING] [OPTION]…
+           approve new test output
+
+       run [OPTION]…
+           run the tests
+
+       status [OPTION]…
+           show test status
+</code></pre>
+<p>Let’s run our test suite with <code>./test run</code> or just <code>./test</code>:</p>
+<pre><code>$ ./test
+Legend:
+• [PASS]: a successful test that was expected to succeed (good);
+• [FAIL]: a failing test that was expected to succeed (needs fixing);
+• [XFAIL]: a failing test that was expected to fail (tolerated failure);
+• [XPASS]: a successful test that was expected to fail (progress?).
+• [MISS]: a test that never ran;
+• [SKIP]: a test that is always skipped but kept around for some reason;
+• [xxxx*]: a new test for which there&#39;s no expected output yet.
+  In this case, you should review the test output and run the &#39;approve&#39;
+  subcommand once you&#39;re satisfied with the output.
+[PASS]  5d41402abc4b hello
+• Path to captured log: _build/testo/status/my_project/5d41402abc4b/log
+1/1 selected test:
+  1 successful (1 pass, 0 xfail)
+  0 unsuccessful (0 fail, 0 xpass)
+overall status: success</code></pre>
+<p>The script <a href="https://github.com/semgrep/testo/blob/main/docsrc/tutorial/run-tutorial">run-tutorial</a> runs all the steps above to create a sample <code>my_test</code> project.</p>
+<p>Congratulations, the “hello” test passed!</p>
+<p>… but did it, though? Did it output <code>hello!</code> like it was supposed to? The output from <code>./test</code> gives us the path to the captured log:</p>
+<pre><code>$ cat _build/testo/status/my_project/5d41402abc4b/log
+hello!</code></pre>
+<p>The test was successful because it didn’t raised any exception, not because it printed <code>hello!</code> correctly.</p>
+<h3 id="make-the-test-check-its-output">Make the test check its output</h3>
+<p>To enforce that our test prints what it’s supposed to, we’re going to specify that we want to capture the standard output (stdout) produced by the test and compare it against a reference. If the output of the test changes in the future, it will be detected and reported as a test failure.</p>
+<p>First, let’s modify the “hello” test to check stdout by specifying the <code>checked_output</code> option:</p>
+<pre><code>let test_hello =
+  Testo.create &quot;hello&quot;
+    ~checked_output:(Testo.stdout ())
+    (fun () -&gt; print_endline &quot;hello!&quot;)
+</code></pre>
+<p>Running <code>./test</code> with the updated code reports a failure and tells us that something’s missing:</p>
+<pre><code>...
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [PASS*] 5d41402abc4b hello                                                   │
+└──────────────────────────────────────────────────────────────────────────────┘
+• Checked output: stdout
+• Missing file containing the expected output: tests/snapshots/my_project/5d41402abc4b/stdout
+• Path to captured stdout: _build/testo/status/my_project/5d41402abc4b/stdout
+• Path to captured log: _build/testo/status/my_project/5d41402abc4b/log
+• Log (stderr) is empty.
+────────────────────────────────────────────────────────────────────────────────
+1/1 selected test:
+  1 successful (1 pass, 0 xfail)
+  0 unsuccessful (0 fail, 0 xpass)
+1 test whose output needs first-time approval
+overall status: failure</code></pre>
+<p>This was expected since we don’t have a reference output for our test. First, we’re going to check that the captured output is what we were expecting:</p>
+<pre><code>$ cat _build/testo/status/my_project/5d41402abc4b/stdout
+hello!</code></pre>
+<p>Note that at any time, we can get a summary of the tests that need attention using <code>./test status</code>, without having to re-run the tests:</p>
+<pre><code>$ ./test status
+[PASS*] 5d41402abc4b hello</code></pre>
+<p>We can see details with the <code>-l</code> (“long output”) option:</p>
+<pre><code>┌──────────────────────────────────────────────────────────────────────────────┐
+│ [PASS*] 5d41402abc4b hello                                                   │
+└──────────────────────────────────────────────────────────────────────────────┘
+• Checked output: stdout
+• Missing file containing the expected output: tests/snapshots/my_project/5d41402abc4b/stdout
+• Path to captured stdout: _build/testo/status/my_project/5d41402abc4b/stdout
+• Path to captured log: _build/testo/status/my_project/5d41402abc4b/log
+• Log (stderr) is empty.
+────────────────────────────────────────────────────────────────────────────────
+1/1 selected test:
+  1 successful (1 pass, 0 xfail)
+  0 unsuccessful (0 fail, 0 xpass)
+1 test whose output needs first-time approval
+overall status: failure</code></pre>
+<p>Then, we’re going to approve this output and make it the reference snapshot with <code>./test approve</code>:</p>
+<pre><code>$ ./test approve
+Expected output changed for 1 test.</code></pre>
+<p>Let’s check the new status:</p>
+<pre><code>$ ./test status</code></pre>
+<p>Nothing is printed because all the tests passed and are in the best state possible. To see the full list of tests, use <code>-a</code> (“all”):</p>
+<pre><code>$ ./test status -a
+[PASS]  5d41402abc4b hello</code></pre>
+<p>Now, there should be a snapshot file somewhere in our file system. Git shows us that <code>tests/snapshots</code> was created:</p>
+<pre><code>$ git status
+...
+Untracked files:
+  (use &quot;git add &lt;file&gt;...&quot; to include in what will be committed)
+    tests/snapshots/</code></pre>
+<p>The snapshot files are organized as follows:</p>
+<pre><code>$ tree tests/snapshots/
+tests/snapshots/
+└── my_project
+    └── 5d41402abc4b
+        ├── name
+        └── stdout
+
+2 directories, 2 files</code></pre>
+<p>The path to the captured output for our test is <code>tests/snapshots/my_project/5d41402abc4b/stdout</code>, as shown in the original test output:</p>
+<pre><code>$ cat tests/snapshots/my_project/5d41402abc4b/stdout
+hello!</code></pre>
+<p>Add the <code>snapshots/</code> folder to the git repository:</p>
+<pre><code>$ git add tests/snapshots
+$ git commit -m &#39;Add test snapshots&#39;</code></pre>
+<h3 id="whats-next">What’s next?</h3>
+<p>You’re now ready to use Testo. To discover more functionality, explore our <a href="../howtos">how-tos</a> and consult the <a href="../reference">reference API</a> for technical details.</p>
 </body>
 </html>

--- a/docsrc/Makefile
+++ b/docsrc/Makefile
@@ -33,6 +33,11 @@ build:
 	rm -rf $(DOCROOT)/reference
 	cp -a ../_build/default/_doc/_html $(DOCROOT)/reference
 
+# Check that the tutorial's sample code works
+.PHONY: test
+test:
+	cd tutorial && ./run-tutorial
+
 $(DOCROOT)/index.html: index.md Makefile
 	$(CONVERT_MARKDOWN_TO_HTML) $< -o $@
 

--- a/docsrc/index.md
+++ b/docsrc/index.md
@@ -2,6 +2,6 @@
 
 Testo is a test framework for OCaml.
 
-* 🚧 [Tutorial](tutorial)
+* [Tutorial](tutorial)
 * 🚧 [Howtos](howtos)
 * [Reference](reference/testo/Testo/)

--- a/docsrc/tutorial/.gitignore
+++ b/docsrc/tutorial/.gitignore
@@ -1,0 +1,1 @@
+/my_project

--- a/docsrc/tutorial/dune
+++ b/docsrc/tutorial/dune
@@ -1,0 +1,2 @@
+; Ignore the demo project created by the tutorial
+(data_only_dirs my_project)

--- a/docsrc/tutorial/index.md
+++ b/docsrc/tutorial/index.md
@@ -1,12 +1,334 @@
 % Testo tutorial
 
-<!--
-1. State the Problem You Are Solving: what's in it for the reader
-2. Prerequisites: knowledge + equipment + time
-3. Installation
-4. 
--->
+Introduction
+--
 
-what's provided?
-should I use it?
-simple example
+Testo is a test framework for OCaml. Like with OUnit or Alcotest, the
+user writes a collection of tests. A test consists of a name and an
+OCaml test function to run, with some options. If the test function returns,
+the test is considered successful but if it raises an exception, it
+is considered failed.
+
+The test suite is compiled into a test executable with a fancy
+command-line interface provided by the Testo library.
+
+Main features
+--
+
+* Most tests can be defined by providing only a name and a function of
+  type `unit -> unit`.
+* Tests can be assigned nested categories of arbitrary depth
+  but are conveniently handled as a single flat list.
+* Tests that are expected to fail ("XFAIL") can be marked as such. This
+  allows writing tests ahead of feature implementation or bug fixes.
+* Supports output snapshots, i.e. capturing stdout or stderr from a
+  test and comparing it with a reference file.
+* Reviewing previous test outcomes can done without rerunning the
+  tests.
+* Provides various utilities for capturing stdout or stderr, and
+  masking variable parts of test output such as temporary file paths.
+* Support for tests that return Lwt promises.
+
+XFAIL outcomes and snapshot files are two features borrowed from
+Pytest that would have required massive changes in Alcotest and led to
+the creation of a new project.
+
+Should I use Testo?
+--
+
+Testo was designed to support older OCaml versions starting from 4.08
+and to be maintained by the community of users. It is being used to test
+[Semgrep](https://github.com/semgrep/semgrep) which has about 5000
+OCaml tests, most of which were originally migrated from Alcotest.
+Check out the
+[known missing features](https://github.com/semgrep/testo/issues) to
+see if anything critical to you is missing.
+
+Getting started
+--
+
+### Install the `testo` library
+
+🚧 ~~Install `testo` with Opam using `opam install testo`~~ For
+now, we recommend using `testo` as a git submodule. Dune will pick
+it up and build it as part of your project like an ordinary library.
+
+### Set up your project
+
+The folder `tests/snapshots/` will be used by Testo to
+store test snapshots to be tracked by your favorite version
+control system (git, ...). Storing other test data under `tests/` is
+encouraged as long as you let Testo manage `tests/snapshots/`.
+
+### Write a test executable
+
+The test executable can be placed anywhere in your Dune project. We
+recommend having only one such program if possible and calling it
+`test`. In this tutorial, we'll put it in the `tests/` folder.
+
+We are going to create the following folders and files:
+
+* `tests/Test.ml`: the entry point of the `test` program
+* `tests/dune`: the Dune file that defines how to build the test executable
+* `tests/snapshots/`: created and managed by Testo, under version control
+* `test`: a symbolic link to `_build/default/tests/test.exe`
+
+Create the following `tests/dune` whose job is to build an ordinary executable
+named `test`:
+
+```
+; Build the test executable for our project
+(executable
+ (name test)
+ (modules Test)
+ (libraries
+    testo
+ )
+)
+```
+
+We recommend running the test program always from the project root so
+as to reference any files using paths relative to the project root.
+Create the symbolic link that will allow us to call the test program
+directly from the project root:
+
+```
+$ ln -s _build/default/tests/test.exe test
+```
+
+If you already have a `test` file or folder, you may pick another
+name for the Testo program, it doesn't matter. The examples in this tutorial
+assume `./test` calls our Testo-based test program.
+
+The last part of this setup is to write the OCaml file
+`tests/Test.ml`. Let's use this:
+
+```
+(*
+   The entry point for the 'test' program that runs the suite of OCaml
+   tests for <this project>.
+*)
+
+let test_hello =
+  Testo.create "hello"
+    (fun () -> print_endline "hello!")
+
+let tests = [
+  test_hello;
+]
+
+let () =
+  Testo.interpret_argv
+    ~project_name:"my_project"
+    (fun () -> tests)
+```
+
+### Check your setup
+
+From the project root, build your project as usual with Dune:
+```
+$ dune build
+```
+
+If everything went according to plan, running the test program with
+`--help` will list the subcommands supported by `./test`:
+
+```
+$ ./test --help
+TEST(1)                           Test Manual                          TEST(1)
+
+
+
+NAME
+       test - run tests for my_project
+
+SYNOPSIS
+       test [COMMAND] …
+
+DESCRIPTION
+
+...
+
+COMMANDS
+       approve [--filter-substring=SUBSTRING] [OPTION]…
+           approve new test output
+
+       run [OPTION]…
+           run the tests
+
+       status [OPTION]…
+           show test status
+
+```
+
+Let's run our test suite with `./test run` or just `./test`:
+
+```
+$ ./test
+Legend:
+• [PASS]: a successful test that was expected to succeed (good);
+• [FAIL]: a failing test that was expected to succeed (needs fixing);
+• [XFAIL]: a failing test that was expected to fail (tolerated failure);
+• [XPASS]: a successful test that was expected to fail (progress?).
+• [MISS]: a test that never ran;
+• [SKIP]: a test that is always skipped but kept around for some reason;
+• [xxxx*]: a new test for which there's no expected output yet.
+  In this case, you should review the test output and run the 'approve'
+  subcommand once you're satisfied with the output.
+[PASS]  5d41402abc4b hello
+• Path to captured log: _build/testo/status/my_project/5d41402abc4b/log
+1/1 selected test:
+  1 successful (1 pass, 0 xfail)
+  0 unsuccessful (0 fail, 0 xpass)
+overall status: success
+```
+
+The script
+[run-tutorial](https://github.com/semgrep/testo/blob/main/docsrc/tutorial/run-tutorial)
+runs all the steps above to create a sample `my_test` project.
+
+Congratulations, the "hello" test passed!
+
+... but did it, though? Did it output `hello!` like it was supposed to?
+The output from `./test` gives us the path to the captured log:
+
+```
+$ cat _build/testo/status/my_project/5d41402abc4b/log
+hello!
+```
+
+The test was successful because it didn't raised any exception, not
+because it printed `hello!` correctly.
+
+### Make the test check its output
+
+To enforce that our test prints what it's supposed to, we're going to
+specify that we want to capture the standard output (stdout) produced
+by the test and compare it against a reference. If the output of the
+test changes in the future, it will be detected and reported as a test
+failure.
+
+First, let's modify the "hello" test to check stdout by specifying the
+`checked_output` option:
+```
+let test_hello =
+  Testo.create "hello"
+    ~checked_output:(Testo.stdout ())
+    (fun () -> print_endline "hello!")
+
+```
+
+Running `./test` with the updated code reports a failure and tells us
+that something's missing:
+```
+...
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [PASS*] 5d41402abc4b hello                                                   │
+└──────────────────────────────────────────────────────────────────────────────┘
+• Checked output: stdout
+• Missing file containing the expected output: tests/snapshots/my_project/5d41402abc4b/stdout
+• Path to captured stdout: _build/testo/status/my_project/5d41402abc4b/stdout
+• Path to captured log: _build/testo/status/my_project/5d41402abc4b/log
+• Log (stderr) is empty.
+────────────────────────────────────────────────────────────────────────────────
+1/1 selected test:
+  1 successful (1 pass, 0 xfail)
+  0 unsuccessful (0 fail, 0 xpass)
+1 test whose output needs first-time approval
+overall status: failure
+```
+
+This was expected since we don't have a reference output for our test.
+First, we're going to check that the captured output is what we were
+expecting:
+```
+$ cat _build/testo/status/my_project/5d41402abc4b/stdout
+hello!
+```
+
+Note that at any time, we can get a summary of the tests that need
+attention using `./test status`, without having to re-run the tests:
+```
+$ ./test status
+[PASS*] 5d41402abc4b hello
+```
+
+We can see details with the `-l` ("long output") option:
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [PASS*] 5d41402abc4b hello                                                   │
+└──────────────────────────────────────────────────────────────────────────────┘
+• Checked output: stdout
+• Missing file containing the expected output: tests/snapshots/my_project/5d41402abc4b/stdout
+• Path to captured stdout: _build/testo/status/my_project/5d41402abc4b/stdout
+• Path to captured log: _build/testo/status/my_project/5d41402abc4b/log
+• Log (stderr) is empty.
+────────────────────────────────────────────────────────────────────────────────
+1/1 selected test:
+  1 successful (1 pass, 0 xfail)
+  0 unsuccessful (0 fail, 0 xpass)
+1 test whose output needs first-time approval
+overall status: failure
+```
+
+Then, we're going to approve this output and make it the reference
+snapshot with `./test approve`:
+```
+$ ./test approve
+Expected output changed for 1 test.
+```
+
+Let's check the new status:
+```
+$ ./test status
+```
+
+Nothing is printed because all the tests passed and are in the best
+state possible. To see the full list of tests, use `-a` ("all"):
+```
+$ ./test status -a
+[PASS]  5d41402abc4b hello
+```
+
+Now, there should be a snapshot file somewhere in our file system.
+Git shows us that `tests/snapshots` was created:
+```
+$ git status
+...
+Untracked files:
+  (use "git add <file>..." to include in what will be committed)
+	tests/snapshots/
+```
+
+The snapshot files are organized as follows:
+```
+$ tree tests/snapshots/
+tests/snapshots/
+└── my_project
+    └── 5d41402abc4b
+        ├── name
+        └── stdout
+
+2 directories, 2 files
+```
+
+The path to the captured output for our test is
+`tests/snapshots/my_project/5d41402abc4b/stdout`, as shown in the
+original test output:
+
+```
+$ cat tests/snapshots/my_project/5d41402abc4b/stdout
+hello!
+```
+
+Add the `snapshots/` folder to the git repository:
+```
+$ git add tests/snapshots
+$ git commit -m 'Add test snapshots'
+```
+
+### What's next?
+
+You're now ready to use Testo. To discover more functionality, explore our
+[how-tos](../howtos) and consult the [reference API](../reference)
+for technical details.

--- a/docsrc/tutorial/index.md
+++ b/docsrc/tutorial/index.md
@@ -1,3 +1,12 @@
 % Testo tutorial
 
-Coming soon!
+<!--
+1. State the Problem You Are Solving: what's in it for the reader
+2. Prerequisites: knowledge + equipment + time
+3. Installation
+4. 
+-->
+
+what's provided?
+should I use it?
+simple example

--- a/docsrc/tutorial/run-tutorial
+++ b/docsrc/tutorial/run-tutorial
@@ -51,7 +51,6 @@ EOF
 
 let test_hello =
   Testo.create "hello"
-    ~checked_output:(Testo.stdout ())
     (fun () -> print_endline "hello!")
 
 let tests = [

--- a/docsrc/tutorial/run-tutorial
+++ b/docsrc/tutorial/run-tutorial
@@ -1,0 +1,76 @@
+#! /usr/bin/env bash
+#
+# Script that performs the steps described in the Testo tutorial
+#
+set -eu
+
+workspace=my_project
+
+# Clean up
+rm -rf "$workspace"
+
+# Create an empty dune/git project
+dune init project my_project
+(
+  cd my_project
+  rm -rf test
+  git init
+
+  # Make git ignore '_build/' (used by both dune and testo)
+  echo _build >> .gitignore
+
+  # Add all the other files
+  git add .
+  git commit -m "First commit"
+
+  # Install testo as a git submodule
+  git submodule add https://github.com/semgrep/testo.git
+
+  # Create the './test' symlink
+  ln -s _build/default/tests/test.exe test
+
+  # Initialize the tests/ folder
+  mkdir -p tests
+  (
+    cd tests
+    cat > dune <<EOF
+; Build the test executable for our project
+(executable
+ (name test)
+ (modules Test)
+ (libraries
+    testo
+ )
+)
+EOF
+    cat > Test.ml <<EOF
+(*
+   The entry point for the 'test' program that runs the suite of OCaml
+   tests for <this project>.
+*)
+
+let test_hello =
+  Testo.create "hello"
+    ~checked_output:(Testo.stdout ())
+    (fun () -> print_endline "hello!")
+
+let tests = [
+  test_hello;
+]
+
+let () =
+  Testo.interpret_argv
+    ~project_name:"my_project"
+    (fun () -> tests)
+EOF
+  )
+
+  # Add the new files to git:
+  git add .
+
+  # Build the project
+  dune build --root=.
+
+  # Run the tests!
+  ./test
+)


### PR DESCRIPTION
Will be visible at https://semgrep.github.io/testo/tutorial/ after merging.

`make doc` will check that the provided script `run-tutorial` works. There is no CI check for it yet.

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
