### PR TITLE
Print compact list of failed tests at the end of each run

### DIFF
--- a/core/Cmd.ml
+++ b/core/Cmd.ml
@@ -65,14 +65,14 @@ let run_with_conf ((get_tests, handle_subcommand_result) : _ test_spec)
   let tests = get_tests () in
   match cmd_conf with
   | Run_tests conf ->
-      Run.run_tests ~always_show_unchecked_output:conf.show_output
+      Run.cmd_run ~always_show_unchecked_output:conf.show_output
         ~filter_by_substring:conf.filter_by_substring
         ~filter_by_tag:conf.filter_by_tag ~lazy_:conf.lazy_ tests
         (fun exit_code tests_with_status ->
           handle_subcommand_result exit_code (Run_result tests_with_status))
   | Status conf ->
       let exit_code, tests_with_status =
-        Run.list_status ~always_show_unchecked_output:conf.show_output
+        Run.cmd_status ~always_show_unchecked_output:conf.show_output
           ~filter_by_substring:conf.filter_by_substring
           ~filter_by_tag:conf.filter_by_tag
           ~output_style:conf.status_output_style tests
@@ -80,7 +80,7 @@ let run_with_conf ((get_tests, handle_subcommand_result) : _ test_spec)
       handle_subcommand_result exit_code (Status_result tests_with_status)
   | Approve conf ->
       let exit_code =
-        Run.approve_output ?filter_by_substring:conf.filter_by_substring
+        Run.cmd_approve ?filter_by_substring:conf.filter_by_substring
           ?filter_by_tag:conf.filter_by_tag tests
       in
       handle_subcommand_result exit_code Approve_result

--- a/core/Run.mli
+++ b/core/Run.mli
@@ -18,7 +18,7 @@ type alcotest_test = string * alcotest_test_case list
 val to_alcotest :
   alcotest_skip:(unit -> _) -> Types.test list -> alcotest_test list
 
-val run_tests :
+val cmd_run :
   always_show_unchecked_output:bool ->
   filter_by_substring:string option ->
   filter_by_tag:Testo_util.Tag.t option ->
@@ -30,7 +30,7 @@ val run_tests :
 (* Print the status of each test.
    Return a non-zero exit status if any of the tests is not a success
    (PASS or XFAIL). *)
-val list_status :
+val cmd_status :
   always_show_unchecked_output:bool ->
   filter_by_substring:string option ->
   filter_by_tag:Testo_util.Tag.t option ->
@@ -38,7 +38,7 @@ val list_status :
   Types.test list ->
   int * Types.test_with_status list
 
-val approve_output :
+val cmd_approve :
   ?filter_by_substring:string ->
   ?filter_by_tag:Testo_util.Tag.t ->
   Types.test list ->

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -247,6 +247,15 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/f66d12950c64/log
 [2m• [0mLog (stderr) is empty.
 [2m────────────────────────────────────────────────────────────────────────────────[0m
+[33m[PASS*] [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m
+[33m[PASS*] [0m0048917873df [36mauto-approve[0m > [36mcapture stderr[0m
+[33m[PASS*] [0m17ec149855c2 [36mauto-approve[0m > [36mcapture stdxxx[0m
+[33m[PASS*] [0m02ac0ea4ae90 [36mauto-approve[0m > [36mcapture stdout and stderr[0m
+[33m[PASS*] [0m25cccdbd5166 [36mauto-approve[0m > [36mcapture stdout in custom location[0m
+[33m[PASS*] [0m8674d1483367 [36mauto-approve[0m > [36mcapture stderr in custom location[0m
+[33m[PASS*] [0medebe706faa8 [36mauto-approve[0m > [36mcapture stdxxx in custom location[0m
+[33m[PASS*] [0md7f47c9a03b6 [36mauto-approve[0m > [36mcapture stdout and stderr in custom location[0m
+[33m[PASS*] [0mf66d12950c64 [36mauto-approve[0m > [36minternal files[0m > [36mcreate name file[0m
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
@@ -539,6 +548,7 @@ Checking if the environment variable TESTO_TEST is set:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/5eff5d8ffb2b/log
 [2m• [0mLog (stderr) is empty.
 [2m────────────────────────────────────────────────────────────────────────────────[0m
+[31m[FAIL]  [0m5eff5d8ffb2b [36menvironment-sensitive[0m
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??


### PR DESCRIPTION
Closes #81

The output of `run` now looks like this in the case of test failures:
![image](https://github.com/semgrep/testo/assets/343265/c7276da0-d758-44b2-afce-c6bffd014ad4)


PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
