### PR TITLE
Add --slice option for distributed/parallel runs

### DIFF
--- a/core/Run.ml
+++ b/core/Run.ml
@@ -728,7 +728,7 @@ let run_tests_sequentially ~always_show_unchecked_output (tests : T.test list) :
     (P.return ()) tests
 
 (* Run this before a run or Lwt run. Returns the filtered tests. *)
-let before_run ~filter_by_substring ~filter_by_tag ~lazy_ tests =
+let before_run ~filter_by_substring ~filter_by_tag ~lazy_ ~slice tests =
   Store.init_workspace ();
   check_test_definitions tests;
   let tests =
@@ -741,7 +741,7 @@ let before_run ~filter_by_substring ~filter_by_tag ~lazy_ tests =
         |> Helpers.list_map (fun (test, _, _) -> test)
   in
   print_status_introduction ();
-  filter ~filter_by_substring ~filter_by_tag tests
+  filter ~filter_by_substring ~filter_by_tag tests |> Slice.apply_slices slice
 
 (* Run this after a run or Lwt run. *)
 let after_run ~always_show_unchecked_output tests selected_tests =
@@ -759,9 +759,9 @@ let after_run ~always_show_unchecked_output tests selected_tests =
    Entry point for the 'run' subcommand
 *)
 let cmd_run ~always_show_unchecked_output ~filter_by_substring ~filter_by_tag
-    ~lazy_ tests cont =
+    ~lazy_ ~slice tests cont =
   let selected_tests =
-    before_run ~filter_by_substring ~filter_by_tag ~lazy_ tests
+    before_run ~filter_by_substring ~filter_by_tag ~lazy_ ~slice tests
   in
   run_tests_sequentially ~always_show_unchecked_output selected_tests
   >>= (fun () ->

--- a/core/Run.mli
+++ b/core/Run.mli
@@ -23,6 +23,7 @@ val cmd_run :
   filter_by_substring:string option ->
   filter_by_tag:Testo_util.Tag.t option ->
   lazy_:bool ->
+  slice:Testo_util.Slice.t list ->
   Types.test list ->
   (int -> Types.test_with_status list -> _) ->
   _

--- a/tests/Test.ml
+++ b/tests/Test.ml
@@ -323,6 +323,10 @@ let tests env =
             Alcotest.fail (sprintf "Invalid value for variable foo: %S" other));
   ]
   @ categorized @ test_internal_files
+  @ Testo.categorize "Slice"
+      (List.map
+         (fun (name, func) -> Testo.create name func)
+         Testo_util.Slice.tests)
 
 let () =
   Testo.interpret_argv ~project_name:"testo_tests"

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -44,6 +44,20 @@ RUN ./test status -e foo=bar
 [33m[MISS]  [0mf66d12950c64 [36mauto-approve[0m > [36minternal files[0m > [36mcreate name file[0m
 [33m[MISS]  [0mcaadabfd495c [36mauto-approve[0m > [36minternal files[0m > [36mdon't create name file[0m
 [33m[MISS]  [0m57b56cb8ada0 [36mauto-approve[0m > [36minternal files[0m > [36mcheck for name file in previous tests[0m
+[33m[MISS]  [0m4a0adc56173a [36mSlice[0m > [36mempty 1/1[0m
+[33m[MISS]  [0m2ae5c882730e [36mSlice[0m > [36mempty 1/5[0m
+[33m[MISS]  [0m5290cda648b1 [36mSlice[0m > [36mempty 5/5[0m
+[33m[MISS]  [0m69942982f070 [36mSlice[0m > [36mshort 1/5[0m
+[33m[MISS]  [0mc7e9d9cc5ced [36mSlice[0m > [36mshort 3/5[0m
+[33m[MISS]  [0m880486950fd4 [36mSlice[0m > [36mshort 4/5[0m
+[33m[MISS]  [0mc7cf03355e3e [36mSlice[0m > [36mshort 5/5[0m
+[33m[MISS]  [0mc248034012cb [36mSlice[0m > [36meven 1/3[0m
+[33m[MISS]  [0mb0f035899167 [36mSlice[0m > [36meven 2/3[0m
+[33m[MISS]  [0m89fe151186d4 [36mSlice[0m > [36meven 3/3[0m
+[33m[MISS]  [0m5a01ad65d512 [36mSlice[0m > [36mlong 1/3[0m
+[33m[MISS]  [0m913605e2d932 [36mSlice[0m > [36mlong 2/3[0m
+[33m[MISS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m
+[33m[MISS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m
 <handling result before exiting>
 RUN ./test run -e foo=bar 
 Legend:
@@ -175,6 +189,34 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/caadabfd495c/log
 [33m[RUN][0m   57b56cb8ada0 [36mauto-approve[0m > [36minternal files[0m > [36mcheck for name file in previous tests[0m...[2K[32m[PASS]  [0m57b56cb8ada0 [36mauto-approve[0m > [36minternal files[0m > [36mcheck for name file in previous tests[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/57b56cb8ada0/log
+[33m[RUN][0m   4a0adc56173a [36mSlice[0m > [36mempty 1/1[0m...[2K[32m[PASS]  [0m4a0adc56173a [36mSlice[0m > [36mempty 1/1[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/4a0adc56173a/log
+[33m[RUN][0m   2ae5c882730e [36mSlice[0m > [36mempty 1/5[0m...[2K[32m[PASS]  [0m2ae5c882730e [36mSlice[0m > [36mempty 1/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/2ae5c882730e/log
+[33m[RUN][0m   5290cda648b1 [36mSlice[0m > [36mempty 5/5[0m...[2K[32m[PASS]  [0m5290cda648b1 [36mSlice[0m > [36mempty 5/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/5290cda648b1/log
+[33m[RUN][0m   69942982f070 [36mSlice[0m > [36mshort 1/5[0m...[2K[32m[PASS]  [0m69942982f070 [36mSlice[0m > [36mshort 1/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/69942982f070/log
+[33m[RUN][0m   c7e9d9cc5ced [36mSlice[0m > [36mshort 3/5[0m...[2K[32m[PASS]  [0mc7e9d9cc5ced [36mSlice[0m > [36mshort 3/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c7e9d9cc5ced/log
+[33m[RUN][0m   880486950fd4 [36mSlice[0m > [36mshort 4/5[0m...[2K[32m[PASS]  [0m880486950fd4 [36mSlice[0m > [36mshort 4/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/880486950fd4/log
+[33m[RUN][0m   c7cf03355e3e [36mSlice[0m > [36mshort 5/5[0m...[2K[32m[PASS]  [0mc7cf03355e3e [36mSlice[0m > [36mshort 5/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c7cf03355e3e/log
+[33m[RUN][0m   c248034012cb [36mSlice[0m > [36meven 1/3[0m...[2K[32m[PASS]  [0mc248034012cb [36mSlice[0m > [36meven 1/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c248034012cb/log
+[33m[RUN][0m   b0f035899167 [36mSlice[0m > [36meven 2/3[0m...[2K[32m[PASS]  [0mb0f035899167 [36mSlice[0m > [36meven 2/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b0f035899167/log
+[33m[RUN][0m   89fe151186d4 [36mSlice[0m > [36meven 3/3[0m...[2K[32m[PASS]  [0m89fe151186d4 [36mSlice[0m > [36meven 3/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/89fe151186d4/log
+[33m[RUN][0m   5a01ad65d512 [36mSlice[0m > [36mlong 1/3[0m...[2K[32m[PASS]  [0m5a01ad65d512 [36mSlice[0m > [36mlong 1/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/5a01ad65d512/log
+[33m[RUN][0m   913605e2d932 [36mSlice[0m > [36mlong 2/3[0m...[2K[32m[PASS]  [0m913605e2d932 [36mSlice[0m > [36mlong 2/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/913605e2d932/log
+[33m[RUN][0m   6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m...[2K[32m[PASS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/6adba8fe4ac9/log
+[33m[RUN][0m   c9bf97cbaabc [36mSlice[0m > [36mchained[0m...[2K[32m[PASS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c9bf97cbaabc/log
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m                           [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
@@ -262,9 +304,9 @@ Legend:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-34/34 selected tests:
+48/48 selected tests:
   1 skipped
-  33 successful (32 pass, 1 xfail)
+  47 successful (46 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -401,6 +443,34 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/caadabfd495c/log
 [32m[PASS]  [0m57b56cb8ada0 [36mauto-approve[0m > [36minternal files[0m > [36mcheck for name file in previous tests[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/57b56cb8ada0/log
+[32m[PASS]  [0m4a0adc56173a [36mSlice[0m > [36mempty 1/1[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/4a0adc56173a/log
+[32m[PASS]  [0m2ae5c882730e [36mSlice[0m > [36mempty 1/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/2ae5c882730e/log
+[32m[PASS]  [0m5290cda648b1 [36mSlice[0m > [36mempty 5/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/5290cda648b1/log
+[32m[PASS]  [0m69942982f070 [36mSlice[0m > [36mshort 1/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/69942982f070/log
+[32m[PASS]  [0mc7e9d9cc5ced [36mSlice[0m > [36mshort 3/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c7e9d9cc5ced/log
+[32m[PASS]  [0m880486950fd4 [36mSlice[0m > [36mshort 4/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/880486950fd4/log
+[32m[PASS]  [0mc7cf03355e3e [36mSlice[0m > [36mshort 5/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c7cf03355e3e/log
+[32m[PASS]  [0mc248034012cb [36mSlice[0m > [36meven 1/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c248034012cb/log
+[32m[PASS]  [0mb0f035899167 [36mSlice[0m > [36meven 2/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b0f035899167/log
+[32m[PASS]  [0m89fe151186d4 [36mSlice[0m > [36meven 3/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/89fe151186d4/log
+[32m[PASS]  [0m5a01ad65d512 [36mSlice[0m > [36mlong 1/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/5a01ad65d512/log
+[32m[PASS]  [0m913605e2d932 [36mSlice[0m > [36mlong 2/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/913605e2d932/log
+[32m[PASS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/6adba8fe4ac9/log
+[32m[PASS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c9bf97cbaabc/log
 
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m                           [2m│[0m
@@ -480,9 +550,9 @@ Legend:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-34/34 selected tests:
+48/48 selected tests:
   1 skipped
-  33 successful (32 pass, 1 xfail)
+  47 successful (46 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -567,7 +637,7 @@ Checking if the environment variable TESTO_TEST is set:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-1/34 selected tests:
+1/48 selected tests:
   0 successful (0 pass, 0 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [31mfailure[0m
@@ -591,7 +661,7 @@ Legend:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-1/34 selected tests:
+1/48 selected tests:
   1 successful (1 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m
@@ -744,6 +814,48 @@ Legend:
 [33m[MISS]  [0m57b56cb8ada0 [36mauto-approve[0m > [36minternal files[0m > [36mcheck for name file in previous tests[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/57b56cb8ada0/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/57b56cb8ada0/log
+[33m[MISS]  [0m4a0adc56173a [36mSlice[0m > [36mempty 1/1[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/4a0adc56173a/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/4a0adc56173a/log
+[33m[MISS]  [0m2ae5c882730e [36mSlice[0m > [36mempty 1/5[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/2ae5c882730e/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/2ae5c882730e/log
+[33m[MISS]  [0m5290cda648b1 [36mSlice[0m > [36mempty 5/5[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/5290cda648b1/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/5290cda648b1/log
+[33m[MISS]  [0m69942982f070 [36mSlice[0m > [36mshort 1/5[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/69942982f070/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/69942982f070/log
+[33m[MISS]  [0mc7e9d9cc5ced [36mSlice[0m > [36mshort 3/5[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c7e9d9cc5ced/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c7e9d9cc5ced/log
+[33m[MISS]  [0m880486950fd4 [36mSlice[0m > [36mshort 4/5[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/880486950fd4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/880486950fd4/log
+[33m[MISS]  [0mc7cf03355e3e [36mSlice[0m > [36mshort 5/5[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c7cf03355e3e/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c7cf03355e3e/log
+[33m[MISS]  [0mc248034012cb [36mSlice[0m > [36meven 1/3[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c248034012cb/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c248034012cb/log
+[33m[MISS]  [0mb0f035899167 [36mSlice[0m > [36meven 2/3[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b0f035899167/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b0f035899167/log
+[33m[MISS]  [0m89fe151186d4 [36mSlice[0m > [36meven 3/3[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/89fe151186d4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/89fe151186d4/log
+[33m[MISS]  [0m5a01ad65d512 [36mSlice[0m > [36mlong 1/3[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/5a01ad65d512/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/5a01ad65d512/log
+[33m[MISS]  [0m913605e2d932 [36mSlice[0m > [36mlong 2/3[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/913605e2d932/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/913605e2d932/log
+[33m[MISS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/6adba8fe4ac9/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/6adba8fe4ac9/log
+[33m[MISS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c9bf97cbaabc/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c9bf97cbaabc/log
 
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m                                                  [2m│[0m
@@ -974,14 +1086,98 @@ Legend:
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/57b56cb8ada0/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/57b56cb8ada0/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m4a0adc56173a [36mSlice[0m > [36mempty 1/1[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/4a0adc56173a/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/4a0adc56173a/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m2ae5c882730e [36mSlice[0m > [36mempty 1/5[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/2ae5c882730e/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/2ae5c882730e/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m5290cda648b1 [36mSlice[0m > [36mempty 5/5[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/5290cda648b1/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/5290cda648b1/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m69942982f070 [36mSlice[0m > [36mshort 1/5[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/69942982f070/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/69942982f070/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mc7e9d9cc5ced [36mSlice[0m > [36mshort 3/5[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c7e9d9cc5ced/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c7e9d9cc5ced/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m880486950fd4 [36mSlice[0m > [36mshort 4/5[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/880486950fd4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/880486950fd4/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mc7cf03355e3e [36mSlice[0m > [36mshort 5/5[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c7cf03355e3e/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c7cf03355e3e/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mc248034012cb [36mSlice[0m > [36meven 1/3[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c248034012cb/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c248034012cb/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mb0f035899167 [36mSlice[0m > [36meven 2/3[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b0f035899167/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b0f035899167/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m89fe151186d4 [36mSlice[0m > [36meven 3/3[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/89fe151186d4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/89fe151186d4/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m5a01ad65d512 [36mSlice[0m > [36mlong 1/3[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/5a01ad65d512/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/5a01ad65d512/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m913605e2d932 [36mSlice[0m > [36mlong 2/3[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/913605e2d932/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/913605e2d932/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/6adba8fe4ac9/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/6adba8fe4ac9/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m                                         [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c9bf97cbaabc/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c9bf97cbaabc/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-34/34 selected tests:
+48/48 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-33 new tests
+47 new tests
 overall status: [31mfailure[0m
 <handling result before exiting>
 RUN ./test status -e foo=bar -l
@@ -1214,14 +1410,98 @@ RUN ./test status -e foo=bar -l
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/57b56cb8ada0/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/57b56cb8ada0/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m4a0adc56173a [36mSlice[0m > [36mempty 1/1[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/4a0adc56173a/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/4a0adc56173a/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m2ae5c882730e [36mSlice[0m > [36mempty 1/5[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/2ae5c882730e/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/2ae5c882730e/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m5290cda648b1 [36mSlice[0m > [36mempty 5/5[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/5290cda648b1/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/5290cda648b1/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m69942982f070 [36mSlice[0m > [36mshort 1/5[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/69942982f070/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/69942982f070/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mc7e9d9cc5ced [36mSlice[0m > [36mshort 3/5[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c7e9d9cc5ced/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c7e9d9cc5ced/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m880486950fd4 [36mSlice[0m > [36mshort 4/5[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/880486950fd4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/880486950fd4/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mc7cf03355e3e [36mSlice[0m > [36mshort 5/5[0m                                       [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c7cf03355e3e/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c7cf03355e3e/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mc248034012cb [36mSlice[0m > [36meven 1/3[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c248034012cb/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c248034012cb/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mb0f035899167 [36mSlice[0m > [36meven 2/3[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b0f035899167/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b0f035899167/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m89fe151186d4 [36mSlice[0m > [36meven 3/3[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/89fe151186d4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/89fe151186d4/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m5a01ad65d512 [36mSlice[0m > [36mlong 1/3[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/5a01ad65d512/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/5a01ad65d512/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m913605e2d932 [36mSlice[0m > [36mlong 2/3[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/913605e2d932/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/913605e2d932/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m                                        [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/6adba8fe4ac9/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/6adba8fe4ac9/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m                                         [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c9bf97cbaabc/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c9bf97cbaabc/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-34/34 selected tests:
+48/48 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-33 new tests
+47 new tests
 overall status: [31mfailure[0m
 <handling result before exiting>
 RUN ./test status -e foo=bar -a
@@ -1259,6 +1539,20 @@ RUN ./test status -e foo=bar -a
 [33m[MISS]  [0mf66d12950c64 [36mauto-approve[0m > [36minternal files[0m > [36mcreate name file[0m
 [33m[MISS]  [0mcaadabfd495c [36mauto-approve[0m > [36minternal files[0m > [36mdon't create name file[0m
 [33m[MISS]  [0m57b56cb8ada0 [36mauto-approve[0m > [36minternal files[0m > [36mcheck for name file in previous tests[0m
+[33m[MISS]  [0m4a0adc56173a [36mSlice[0m > [36mempty 1/1[0m
+[33m[MISS]  [0m2ae5c882730e [36mSlice[0m > [36mempty 1/5[0m
+[33m[MISS]  [0m5290cda648b1 [36mSlice[0m > [36mempty 5/5[0m
+[33m[MISS]  [0m69942982f070 [36mSlice[0m > [36mshort 1/5[0m
+[33m[MISS]  [0mc7e9d9cc5ced [36mSlice[0m > [36mshort 3/5[0m
+[33m[MISS]  [0m880486950fd4 [36mSlice[0m > [36mshort 4/5[0m
+[33m[MISS]  [0mc7cf03355e3e [36mSlice[0m > [36mshort 5/5[0m
+[33m[MISS]  [0mc248034012cb [36mSlice[0m > [36meven 1/3[0m
+[33m[MISS]  [0mb0f035899167 [36mSlice[0m > [36meven 2/3[0m
+[33m[MISS]  [0m89fe151186d4 [36mSlice[0m > [36meven 3/3[0m
+[33m[MISS]  [0m5a01ad65d512 [36mSlice[0m > [36mlong 1/3[0m
+[33m[MISS]  [0m913605e2d932 [36mSlice[0m > [36mlong 2/3[0m
+[33m[MISS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m
+[33m[MISS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m
 <handling result before exiting>
 RUN ./test run -e foo=bar 
 Legend:
@@ -1387,12 +1681,40 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/caadabfd495c/log
 [33m[RUN][0m   57b56cb8ada0 [36mauto-approve[0m > [36minternal files[0m > [36mcheck for name file in previous tests[0m...[2K[32m[PASS]  [0m57b56cb8ada0 [36mauto-approve[0m > [36minternal files[0m > [36mcheck for name file in previous tests[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/57b56cb8ada0/log
+[33m[RUN][0m   4a0adc56173a [36mSlice[0m > [36mempty 1/1[0m...[2K[32m[PASS]  [0m4a0adc56173a [36mSlice[0m > [36mempty 1/1[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/4a0adc56173a/log
+[33m[RUN][0m   2ae5c882730e [36mSlice[0m > [36mempty 1/5[0m...[2K[32m[PASS]  [0m2ae5c882730e [36mSlice[0m > [36mempty 1/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/2ae5c882730e/log
+[33m[RUN][0m   5290cda648b1 [36mSlice[0m > [36mempty 5/5[0m...[2K[32m[PASS]  [0m5290cda648b1 [36mSlice[0m > [36mempty 5/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/5290cda648b1/log
+[33m[RUN][0m   69942982f070 [36mSlice[0m > [36mshort 1/5[0m...[2K[32m[PASS]  [0m69942982f070 [36mSlice[0m > [36mshort 1/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/69942982f070/log
+[33m[RUN][0m   c7e9d9cc5ced [36mSlice[0m > [36mshort 3/5[0m...[2K[32m[PASS]  [0mc7e9d9cc5ced [36mSlice[0m > [36mshort 3/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c7e9d9cc5ced/log
+[33m[RUN][0m   880486950fd4 [36mSlice[0m > [36mshort 4/5[0m...[2K[32m[PASS]  [0m880486950fd4 [36mSlice[0m > [36mshort 4/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/880486950fd4/log
+[33m[RUN][0m   c7cf03355e3e [36mSlice[0m > [36mshort 5/5[0m...[2K[32m[PASS]  [0mc7cf03355e3e [36mSlice[0m > [36mshort 5/5[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c7cf03355e3e/log
+[33m[RUN][0m   c248034012cb [36mSlice[0m > [36meven 1/3[0m...[2K[32m[PASS]  [0mc248034012cb [36mSlice[0m > [36meven 1/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c248034012cb/log
+[33m[RUN][0m   b0f035899167 [36mSlice[0m > [36meven 2/3[0m...[2K[32m[PASS]  [0mb0f035899167 [36mSlice[0m > [36meven 2/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b0f035899167/log
+[33m[RUN][0m   89fe151186d4 [36mSlice[0m > [36meven 3/3[0m...[2K[32m[PASS]  [0m89fe151186d4 [36mSlice[0m > [36meven 3/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/89fe151186d4/log
+[33m[RUN][0m   5a01ad65d512 [36mSlice[0m > [36mlong 1/3[0m...[2K[32m[PASS]  [0m5a01ad65d512 [36mSlice[0m > [36mlong 1/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/5a01ad65d512/log
+[33m[RUN][0m   913605e2d932 [36mSlice[0m > [36mlong 2/3[0m...[2K[32m[PASS]  [0m913605e2d932 [36mSlice[0m > [36mlong 2/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/913605e2d932/log
+[33m[RUN][0m   6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m...[2K[32m[PASS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/6adba8fe4ac9/log
+[33m[RUN][0m   c9bf97cbaabc [36mSlice[0m > [36mchained[0m...[2K[32m[PASS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/c9bf97cbaabc/log
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-34/34 selected tests:
+48/48 selected tests:
   1 skipped
-  33 successful (32 pass, 1 xfail)
+  47 successful (46 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m
 <handling result before exiting>

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -57,7 +57,9 @@ RUN ./test status -e foo=bar
 [33m[MISS]  [0m5a01ad65d512 [36mSlice[0m > [36mlong 1/3[0m
 [33m[MISS]  [0m913605e2d932 [36mSlice[0m > [36mlong 2/3[0m
 [33m[MISS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m
-[33m[MISS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m
+[33m[MISS]  [0m8a4a3d95651b [36mSlice[0m > [36mchained 1/3 2/2[0m
+[33m[MISS]  [0ma8cc405c1f92 [36mSlice[0m > [36mchained 2/3 1/2[0m
+[33m[MISS]  [0m74333515fe26 [36mSlice[0m > [36mchained 2/3 2/2[0m
 <handling result before exiting>
 RUN ./test run -e foo=bar 
 Legend:
@@ -215,8 +217,12 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/913605e2d932/log
 [33m[RUN][0m   6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m...[2K[32m[PASS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/6adba8fe4ac9/log
-[33m[RUN][0m   c9bf97cbaabc [36mSlice[0m > [36mchained[0m...[2K[32m[PASS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/c9bf97cbaabc/log
+[33m[RUN][0m   8a4a3d95651b [36mSlice[0m > [36mchained 1/3 2/2[0m...[2K[32m[PASS]  [0m8a4a3d95651b [36mSlice[0m > [36mchained 1/3 2/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/8a4a3d95651b/log
+[33m[RUN][0m   a8cc405c1f92 [36mSlice[0m > [36mchained 2/3 1/2[0m...[2K[32m[PASS]  [0ma8cc405c1f92 [36mSlice[0m > [36mchained 2/3 1/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a8cc405c1f92/log
+[33m[RUN][0m   74333515fe26 [36mSlice[0m > [36mchained 2/3 2/2[0m...[2K[32m[PASS]  [0m74333515fe26 [36mSlice[0m > [36mchained 2/3 2/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/74333515fe26/log
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m                           [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
@@ -304,9 +310,9 @@ Legend:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-48/48 selected tests:
+50/50 selected tests:
   1 skipped
-  47 successful (46 pass, 1 xfail)
+  49 successful (48 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -469,8 +475,12 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/913605e2d932/log
 [32m[PASS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/6adba8fe4ac9/log
-[32m[PASS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/c9bf97cbaabc/log
+[32m[PASS]  [0m8a4a3d95651b [36mSlice[0m > [36mchained 1/3 2/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/8a4a3d95651b/log
+[32m[PASS]  [0ma8cc405c1f92 [36mSlice[0m > [36mchained 2/3 1/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a8cc405c1f92/log
+[32m[PASS]  [0m74333515fe26 [36mSlice[0m > [36mchained 2/3 2/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/74333515fe26/log
 
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m                           [2m│[0m
@@ -550,9 +560,9 @@ Legend:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-48/48 selected tests:
+50/50 selected tests:
   1 skipped
-  47 successful (46 pass, 1 xfail)
+  49 successful (48 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -637,7 +647,7 @@ Checking if the environment variable TESTO_TEST is set:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-1/48 selected tests:
+1/50 selected tests:
   0 successful (0 pass, 0 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [31mfailure[0m
@@ -661,7 +671,7 @@ Legend:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-1/48 selected tests:
+1/50 selected tests:
   1 successful (1 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m
@@ -853,9 +863,15 @@ Legend:
 [33m[MISS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/6adba8fe4ac9/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/6adba8fe4ac9/log
-[33m[MISS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c9bf97cbaabc/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/c9bf97cbaabc/log
+[33m[MISS]  [0m8a4a3d95651b [36mSlice[0m > [36mchained 1/3 2/2[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8a4a3d95651b/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/8a4a3d95651b/log
+[33m[MISS]  [0ma8cc405c1f92 [36mSlice[0m > [36mchained 2/3 1/2[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/a8cc405c1f92/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a8cc405c1f92/log
+[33m[MISS]  [0m74333515fe26 [36mSlice[0m > [36mchained 2/3 2/2[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/74333515fe26/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/74333515fe26/log
 
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m                                                  [2m│[0m
@@ -1165,19 +1181,31 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/6adba8fe4ac9/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m                                         [2m│[0m
+[0m[2m│[0m [33m[MISS]  [0m8a4a3d95651b [36mSlice[0m > [36mchained 1/3 2/2[0m                                 [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c9bf97cbaabc/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/c9bf97cbaabc/log
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8a4a3d95651b/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/8a4a3d95651b/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0ma8cc405c1f92 [36mSlice[0m > [36mchained 2/3 1/2[0m                                 [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/a8cc405c1f92/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a8cc405c1f92/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m74333515fe26 [36mSlice[0m > [36mchained 2/3 2/2[0m                                 [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/74333515fe26/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/74333515fe26/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-48/48 selected tests:
+50/50 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-47 new tests
+49 new tests
 overall status: [31mfailure[0m
 <handling result before exiting>
 RUN ./test status -e foo=bar -l
@@ -1489,19 +1517,31 @@ RUN ./test status -e foo=bar -l
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/6adba8fe4ac9/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m                                         [2m│[0m
+[0m[2m│[0m [33m[MISS]  [0m8a4a3d95651b [36mSlice[0m > [36mchained 1/3 2/2[0m                                 [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/c9bf97cbaabc/outcome[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/c9bf97cbaabc/log
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8a4a3d95651b/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/8a4a3d95651b/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0ma8cc405c1f92 [36mSlice[0m > [36mchained 2/3 1/2[0m                                 [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/a8cc405c1f92/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a8cc405c1f92/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m74333515fe26 [36mSlice[0m > [36mchained 2/3 2/2[0m                                 [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/74333515fe26/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/74333515fe26/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-48/48 selected tests:
+50/50 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-47 new tests
+49 new tests
 overall status: [31mfailure[0m
 <handling result before exiting>
 RUN ./test status -e foo=bar -a
@@ -1552,7 +1592,9 @@ RUN ./test status -e foo=bar -a
 [33m[MISS]  [0m5a01ad65d512 [36mSlice[0m > [36mlong 1/3[0m
 [33m[MISS]  [0m913605e2d932 [36mSlice[0m > [36mlong 2/3[0m
 [33m[MISS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m
-[33m[MISS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m
+[33m[MISS]  [0m8a4a3d95651b [36mSlice[0m > [36mchained 1/3 2/2[0m
+[33m[MISS]  [0ma8cc405c1f92 [36mSlice[0m > [36mchained 2/3 1/2[0m
+[33m[MISS]  [0m74333515fe26 [36mSlice[0m > [36mchained 2/3 2/2[0m
 <handling result before exiting>
 RUN ./test run -e foo=bar 
 Legend:
@@ -1707,14 +1749,18 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/913605e2d932/log
 [33m[RUN][0m   6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m...[2K[32m[PASS]  [0m6adba8fe4ac9 [36mSlice[0m > [36mlong 3/3[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/6adba8fe4ac9/log
-[33m[RUN][0m   c9bf97cbaabc [36mSlice[0m > [36mchained[0m...[2K[32m[PASS]  [0mc9bf97cbaabc [36mSlice[0m > [36mchained[0m
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/c9bf97cbaabc/log
+[33m[RUN][0m   8a4a3d95651b [36mSlice[0m > [36mchained 1/3 2/2[0m...[2K[32m[PASS]  [0m8a4a3d95651b [36mSlice[0m > [36mchained 1/3 2/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/8a4a3d95651b/log
+[33m[RUN][0m   a8cc405c1f92 [36mSlice[0m > [36mchained 2/3 1/2[0m...[2K[32m[PASS]  [0ma8cc405c1f92 [36mSlice[0m > [36mchained 2/3 1/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a8cc405c1f92/log
+[33m[RUN][0m   74333515fe26 [36mSlice[0m > [36mchained 2/3 2/2[0m...[2K[32m[PASS]  [0m74333515fe26 [36mSlice[0m > [36mchained 2/3 2/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/74333515fe26/log
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-48/48 selected tests:
+50/50 selected tests:
   1 skipped
-  47 successful (46 pass, 1 xfail)
+  49 successful (48 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m
 <handling result before exiting>

--- a/util/Slice.ml
+++ b/util/Slice.ml
@@ -1,0 +1,80 @@
+(*
+   A slice is a range of tests defined by the slice number and the total
+   number of slices such as "3/4" or "2/8".
+*)
+
+open Printf
+
+type t = { num : int; out_of : int }
+
+let create ~num ~out_of =
+  if num >= 1 && num <= out_of then Some { num; out_of } else None
+
+let of_string str =
+  match String.split_on_char '/' str with
+  | [ a; b ] -> (
+      try create ~num:(int_of_string a) ~out_of:(int_of_string b) with
+      | _ -> None)
+  | _ -> None
+
+let to_string { num; out_of } = Printf.sprintf "%d/%d" num out_of
+
+let apply_to_array { num; out_of } ar =
+  let len = Array.length ar in
+  let slice_len =
+    (* length of a slice except for the last slice which may be shorter *)
+    if len mod out_of = 0 then len / out_of else (len / out_of) + 1
+  in
+  assert (slice_len * out_of >= len);
+  let start_index = slice_len * (num - 1) in
+  if start_index >= len then [||]
+  else
+    let end_index = min (slice_len * num) len in
+    (*
+      printf "%i/%i: len=%i, slice_len=%i, start=%i, end=%i\n%!"
+        num out_of len slice_len start_index end_index;
+    *)
+    Array.sub ar start_index (end_index - start_index)
+
+let apply slice list =
+  list |> Array.of_list |> apply_to_array slice |> Array.to_list
+
+let apply_slices slices list =
+  List.fold_left (fun acc slice -> apply slice acc) list slices
+
+(****************** Unit tests **********************)
+
+let string_of_list xs =
+  sprintf "[%s]" (xs |> List.map string_of_int |> String.concat ",")
+
+let tests =
+  [
+    ("empty 1/1", [ "1/1" ], [], []);
+    ("empty 1/5", [ "1/5" ], [], []);
+    ("empty 5/5", [ "5/5" ], [], []);
+    ("short 1/5", [ "1/5" ], [ 1; 2; 3 ], [ 1 ]);
+    ("short 3/5", [ "3/5" ], [ 1; 2; 3 ], [ 3 ]);
+    ("short 4/5", [ "4/5" ], [ 1; 2; 3 ], []);
+    ("short 5/5", [ "5/5" ], [ 1; 2; 3 ], []);
+    ("even 1/3", [ "1/3" ], [ 1; 2; 3; 4; 5; 6 ], [ 1; 2 ]);
+    ("even 2/3", [ "2/3" ], [ 1; 2; 3; 4; 5; 6 ], [ 3; 4 ]);
+    ("even 3/3", [ "3/3" ], [ 1; 2; 3; 4; 5; 6 ], [ 5; 6 ]);
+    ("long 1/3", [ "1/3" ], [ 1; 2; 3; 4; 5; 6; 7; 8; 9; 10 ], [ 1; 2; 3; 4 ]);
+    ("long 2/3", [ "2/3" ], [ 1; 2; 3; 4; 5; 6; 7; 8; 9; 10 ], [ 5; 6; 7; 8 ]);
+    ("long 3/3", [ "3/3" ], [ 1; 2; 3; 4; 5; 6; 7; 8; 9; 10 ], [ 9; 10 ]);
+    ("chained", [ "1/3"; "2/2" ], [ 1; 2; 3; 4; 5; 6; 7; 8; 9; 10 ], [ 3; 4 ]);
+  ]
+  |> List.map (fun (name, slice_strs, input, expected_result) ->
+         let func () =
+           printf "Expected result: %s\n%!" (string_of_list expected_result);
+           let slices =
+             List.map of_string slice_strs
+             |> List.map (function
+                  | Some x -> x
+                  | None -> assert false)
+           in
+           let result = apply_slices slices input in
+           printf "Result: %s\n%!" (string_of_list result);
+           assert (result = expected_result)
+         in
+         (name, func))

--- a/util/Slice.ml
+++ b/util/Slice.ml
@@ -38,8 +38,10 @@ let apply_to_array slice ar =
   in
   let start_index = get_slice_start slice.num in
   let end_index = get_slice_start (slice.num + 1) in
-  printf "%s: len=%i, min_slice_len=%i, start=%i, end=%i\n%!" (to_string slice)
-    n min_slice_len start_index end_index;
+  (*
+  printf "%s: len=%i, min_slice_len=%i, start=%i, end=%i\n%!"
+    (to_string slice) n min_slice_len start_index end_index;
+  *)
   Array.sub ar start_index (end_index - start_index)
 
 let apply slice list =

--- a/util/Slice.mli
+++ b/util/Slice.mli
@@ -1,0 +1,23 @@
+(*
+   A slice is a range of tests defined by the slice number and the total
+   number of slices such as "3/4" or "2/8".
+
+   It is used to split a test suite into smaller test suites for
+   parallel execution.
+*)
+
+(*
+   A slice denoted "3/4" is the third slice out of four slices and is
+   represented by { num = 3; out_of = 4 }.
+*)
+type t = private { num : int; out_of : int }
+
+val of_string : string -> t option
+val to_string : t -> string
+
+(* Take a slice out of a list *)
+val apply : t -> 'a list -> 'a list
+
+(* Take a slice, then take a slice within that slice, and so on *)
+val apply_slices : t list -> 'a list -> 'a list
+val tests : (string * (unit -> unit)) list


### PR DESCRIPTION
This allows splitting a CI job into multiple jobs using e.g.
```
./test --slice 1/4
./test --slice 2/4
./test --slice 3/4
./test --slice 4/4
```

It is also the first step toward a `-j` option that does the splitting for us and merges the results in an orderly fashion (#8).

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
