### PR TITLE
Add missing space leading the lines of context in diff output

### DIFF
--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -618,10 +618,10 @@ Legend:
 [1m--- tests/snapshots/testo_tests/5eff5d8ffb2b/stdout[0m
 [1m+++ _build/testo/status/testo_tests/5eff5d8ffb2b/stdout[0m
 [36m@@ -1,3 +1,3 @@[0m
-Checking if the environment variable TESTO_TEST is set:
+ Checking if the environment variable TESTO_TEST is set:
 [31m-TESTO_TEST is empty or unset.[0m
 [32m+TESTO_TEST is set to "hello".[0m
-
+ 
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/5eff5d8ffb2b/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/5eff5d8ffb2b/stdout
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/5eff5d8ffb2b/log
@@ -634,10 +634,10 @@ Checking if the environment variable TESTO_TEST is set:
 [1m--- tests/snapshots/testo_tests/5eff5d8ffb2b/stdout[0m
 [1m+++ _build/testo/status/testo_tests/5eff5d8ffb2b/stdout[0m
 [36m@@ -1,3 +1,3 @@[0m
-Checking if the environment variable TESTO_TEST is set:
+ Checking if the environment variable TESTO_TEST is set:
 [31m-TESTO_TEST is empty or unset.[0m
 [32m+TESTO_TEST is set to "hello".[0m
-
+ 
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/5eff5d8ffb2b/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/5eff5d8ffb2b/stdout
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/5eff5d8ffb2b/log

--- a/util/Diff.ml
+++ b/util/Diff.ml
@@ -157,7 +157,7 @@ let format_header ~color buf path1 path2 =
     (Style.opt_color color Bold line2)
 
 let format_context buf lines =
-  Array.iter (fun line -> bprintf buf "%s\n" line) lines
+  Array.iter (fun line -> bprintf buf " %s\n" line) lines
 
 let format_edit ~color buf (x : diff) =
   match x with


### PR DESCRIPTION
A diff was incorrectly shown as follows:
```
context line 1
-deleted line
+added line
context line 2
```

The context lines are now correctly indented so as to align with the +/- lines:
```
 context line 1
-deleted line
+added line
 context line 2
```

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
