### PR TITLE
Show exceptions raised by tests independently of showing/hiding stderr

### DIFF
--- a/core/Run.ml
+++ b/core/Run.ml
@@ -582,6 +582,14 @@ let print_status ~highlight_test ~always_show_unchecked_output
                   ())
           | OK
           | OK_but_new
+            when always_show_unchecked_output -> (
+              match Store.get_exception test with
+              | Some msg ->
+                  printf "%sException raised by the test:\n%s" bullet
+                    (Style.color Green (Style.quote_multiline_text msg))
+              | None -> ())
+          | OK
+          | OK_but_new
           | Not_OK (Some Wrong_output)
           | Not_OK None ->
               ()));

--- a/core/Store.mli
+++ b/core/Store.mli
@@ -46,6 +46,21 @@ type capture_paths = {
 val capture_paths_of_test : Types.test -> capture_paths list
 
 (*
+   Record exception and stack trace raised by a test in a file.
+
+   If the argument is 'None', the file is deleted if it exists.
+   If the argument is 'Some msg', 'msg' is saved. 'msg' must be
+   a human-readable representation of the exception raised by the test.
+*)
+val store_exception : Types.test -> string option -> unit
+
+(*
+   Get the contents of the file containing the exception raised by a test.
+   This file exists if the test failed due to an exception.
+*)
+val get_exception : Types.test -> string option
+
+(*
    Ordinary output that's not compared against expectations.
    This is what's left of stdout and stderr after redirections.
 

--- a/tests/Failing_test.ml
+++ b/tests/Failing_test.ml
@@ -28,6 +28,8 @@ non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     t "doesn't contain substring" ~checked_output:(Testo.stdout ())
       ~normalize:[ Testo.mask_not_substring "water" ]
       (fun () -> print_string "fire");
+    t "show exception when capturing stderr" ~checked_output:(Testo.stderr ())
+      (fun () -> failwith "blah");
   ]
 
 let () = Testo.interpret_argv ~project_name:"testo_failing_tests" tests

--- a/tests/snapshots/testo_failing_tests/b6c9cb0d2045/name
+++ b/tests/snapshots/testo_failing_tests/b6c9cb0d2045/name
@@ -1,0 +1,1 @@
+show exception when capturing stderr


### PR DESCRIPTION
Fixes #93 

* When a test fails with an exception but stderr is captured a snapshot, the exception is now shown (in red) even if stderr is captured as a snapshot and not shown.
* When a test that's expected to fail succeeds, the exception is now shown (in green) in verbose mode (`status -v`).

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
