### PR TITLE
Fix alcotest export

### DIFF
--- a/core/Run.ml
+++ b/core/Run.ml
@@ -357,7 +357,8 @@ let conditional_wrap condition wrapper func =
   if condition then wrapper func else func
 
 let wrap_test_function ~with_storage ~flip_xfail_outcome test func =
-  func |> with_store_exception test
+  func
+  |> conditional_wrap with_storage (with_store_exception test)
   |> conditional_wrap flip_xfail_outcome (with_flip_xfail_outcome test)
   |> protect_globals test
   |> conditional_wrap with_storage (Store.with_result_capture test)

--- a/core/Store.ml
+++ b/core/Store.ml
@@ -103,10 +103,14 @@ let default_status_workspace_root = Fpath.v "_build" / "testo" / "status"
 let default_expectation_workspace_root = Fpath.v "tests" / "snapshots"
 
 let not_initialized () =
-  Error.user_error "Missing initialization call: Testo.init ()"
+  Error.user_error
+    "The Testo workspace was not initialized properly or at all. This is \
+     probably a bug in Testo."
 
 let already_initialized () =
-  Error.user_error "Multiple initialization calls to Testo.init. Keep only one."
+  Error.user_error
+    "Internal error in Testo: there was an attempt to initialize the workspace \
+     more than once."
 
 let make_late_init () =
   let var = ref None in


### PR DESCRIPTION
This fixes a storage bug when running exported tests in Alcotest.

e.g.
``` ┌──────────────────────────────────────────────────────────────────────────────┐
  │ [FAIL]        fa42a29dc6d2 Language Server (e2e)          0   Test LS.       │
  └──────────────────────────────────────────────────────────────────────────────┘
  [exception] Error: Missing initialization call: Testo.init ()
  Logs saved to `/__w/semgrep-proprietary/semgrep-proprietary/js/tests/_build/_tests/semgrep-js/fa42a29dc6d2 Language Server U+0028e2eU+0029.000.output'.
```

We don't have tests for the Alcotest export. For now, errors are caught in the semgrep repo where Alcotest is used to run some tests in JavaScript.

PR checklist:

- [x] Purpose of the code is evident to future readers
- [ ] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
