### PR TITLE
Add option to force a test to run alone (not concurrently with other tests)

### DIFF
--- a/core/Run.ml
+++ b/core/Run.ml
@@ -186,18 +186,20 @@ let stats_of_tests tests tests_with_status =
   in
   tests_with_status
   |> List.iter (fun ((test : T.test), _status, (sum : T.status_summary)) ->
-         if test.skipped then incr stats.skipped_tests
-         else (
-           (match sum.status_class with
-           | MISS -> ()
-           | _ -> if not sum.has_expected_output then incr stats.needs_approval);
-           incr
+         match test.skipped with
+         | Some _reason -> incr stats.skipped_tests
+         | None ->
              (match sum.status_class with
-             | PASS -> stats.pass
-             | FAIL _ -> stats.fail
-             | XFAIL _ -> stats.xfail
-             | XPASS -> stats.xpass
-             | MISS -> stats.miss)));
+             | MISS -> ()
+             | _ ->
+                 if not sum.has_expected_output then incr stats.needs_approval);
+             incr
+               (match sum.status_class with
+               | PASS -> stats.pass
+               | FAIL _ -> stats.fail
+               | XFAIL _ -> stats.xfail
+               | XPASS -> stats.xpass
+               | MISS -> stats.miss));
   stats
 
 (* Sample output: "", " {foo, bar}" *)
@@ -310,15 +312,17 @@ let to_alcotest_gen ~(alcotest_skip : unit -> _)
               A "skipped" test is marked as skipped in Alcotest's run output
               and leaves no trace such that Testo thinks it never ran.
            *)
-           if test.skipped then (fun () ->
-             alcotest_skip () |> ignore;
-             Error.user_error
-               "The function 'alcotest_skip' passed to 'Testo.to_alcotest' \
-                didn't raise\n\
-                an exception as expected. 'Testo.to_alcotest' should be called \
-                with\n\
-                '~alcotest_skip:Alcotest.skip'.")
-           else (wrap_test_function test test.func : unit -> _)
+           match test.skipped with
+           | Some _reason ->
+               fun () ->
+                 alcotest_skip () |> ignore;
+                 Error.user_error
+                   "The function 'alcotest_skip' passed to 'Testo.to_alcotest' \
+                    didn't raise\n\
+                    an exception as expected. 'Testo.to_alcotest' should be \
+                    called with\n\
+                    '~alcotest_skip:Alcotest.skip'."
+           | None -> (wrap_test_function test test.func : unit -> _)
          in
          (* This is the format expected by Alcotest: *)
          (suite_name, (test.name, `Quick, func)))
@@ -425,7 +429,7 @@ let print_errors (xs : (Store.changed, string) Result.t list) : int =
       exit_failure
 
 let is_important_status ((test : T.test), _status, (sum : T.status_summary)) =
-  (not test.skipped)
+  test.skipped = None
   && ((not sum.has_expected_output)
      ||
      match success_of_status_summary sum with
@@ -498,102 +502,107 @@ let print_status ~highlight_test ~always_show_unchecked_output
     (((test : T.test), (status : T.status), sum) as test_with_status) =
   let title = format_one_line_status test_with_status in
   with_highlight_test ~highlight_test ~title (fun () ->
-      if (* Details about expectations *)
-         test.skipped then printf "%sAlways skipped\n" bullet
-      else (
-        (match status.expectation.expected_outcome with
-        | Should_succeed -> ()
-        | Should_fail reason -> printf "%sExpected to fail: %s\n" bullet reason);
-        (match test.checked_output with
-        | Ignore_output -> ()
-        | _ ->
-            let text =
-              match test.checked_output with
-              | Ignore_output -> Error.assert_false ~__LOC__ ()
-              | Stdout _ -> "stdout"
-              | Stderr _ -> "stderr"
-              | Stdxxx _ -> "merged stdout and stderr"
-              | Split_stdout_stderr _ -> "separate stdout and stderr"
-            in
-            printf "%sChecked output: %s\n" bullet text);
-        (* Details about results *)
-        (match status.expectation.expected_output with
-        | Error (Missing_files [ path ]) ->
-            print_error
-              (sprintf "Missing file containing the expected output: %s" !!path)
-        | Error (Missing_files paths) ->
-            print_error
-              (sprintf "Missing files containing the expected output: %s"
-                 (String.concat ", " (Fpath_.to_string_list paths)))
-        | Ok _expected_output -> (
-            match status.result with
-            | Error (Missing_files [ path ]) ->
-                print_error
-                  (sprintf "Missing file containing the test output: %s" !!path)
-            | Error (Missing_files paths) ->
-                print_error
-                  (sprintf "Missing files containing the test output: %s"
-                     (String.concat ", " (Fpath_.to_string_list paths)))
-            | Ok _ -> ()));
-        let capture_paths = Store.capture_paths_of_test test in
-        show_output_details test sum capture_paths;
-        let success = success_of_status_summary sum in
-        let show_unchecked_output =
-          always_show_unchecked_output
-          ||
-          match success with
-          | OK -> false
-          | OK_but_new -> true
-          | Not_OK _ -> true
-        in
-        (* TODO: show the checked output to be approved? *)
-        (if show_unchecked_output then
-           match Store.get_unchecked_output test with
-           | None -> (
-               match success with
-               | OK -> ()
-               | OK_but_new -> ()
-               | Not_OK (Some (Exception | Exception_and_wrong_output)) ->
-                   printf "%sFailed due to an exception. See captured output.\n"
-                     bullet
-               | Not_OK (Some Wrong_output) ->
-                   printf "%sFailed due to wrong output.\n" bullet
-               | Not_OK None ->
-                   printf
-                     "%sSucceded when it should have failed. See captured \
-                      output.\n"
-                     bullet)
-           | Some (log_description, data) -> (
-               match data with
-               | "" -> printf "%sLog (%s) is empty.\n" bullet log_description
-               | _ ->
-                   printf "%sLog (%s):\n%s" bullet log_description
-                     (Style.quote_multiline_text data);
-                   if not (ends_with_newline data) then print_char '\n'));
-        (* Show the exception in case of a test failure due to an exception *)
-        if show_unchecked_output then
-          match success with
-          | Not_OK (Some (Exception | Exception_and_wrong_output)) -> (
-              match Store.get_exception test with
-              | Some msg ->
-                  printf "%sException raised by the test:\n%s" bullet
-                    (Style.color Red (Style.quote_multiline_text msg))
-              | None ->
-                  (* = assert false *)
-                  ())
-          | OK
-          | OK_but_new
-            when always_show_unchecked_output -> (
-              match Store.get_exception test with
-              | Some msg ->
-                  printf "%sException raised by the test:\n%s" bullet
-                    (Style.color Green (Style.quote_multiline_text msg))
-              | None -> ())
-          | OK
-          | OK_but_new
-          | Not_OK (Some Wrong_output)
-          | Not_OK None ->
-              ()));
+      (* Details about expectations *)
+      match test.skipped with
+      | Some _reason -> printf "%sAlways skipped\n" bullet
+      | None -> (
+          (match status.expectation.expected_outcome with
+          | Should_succeed -> ()
+          | Should_fail reason ->
+              printf "%sExpected to fail: %s\n" bullet reason);
+          (match test.checked_output with
+          | Ignore_output -> ()
+          | _ ->
+              let text =
+                match test.checked_output with
+                | Ignore_output -> Error.assert_false ~__LOC__ ()
+                | Stdout _ -> "stdout"
+                | Stderr _ -> "stderr"
+                | Stdxxx _ -> "merged stdout and stderr"
+                | Split_stdout_stderr _ -> "separate stdout and stderr"
+              in
+              printf "%sChecked output: %s\n" bullet text);
+          (* Details about results *)
+          (match status.expectation.expected_output with
+          | Error (Missing_files [ path ]) ->
+              print_error
+                (sprintf "Missing file containing the expected output: %s"
+                   !!path)
+          | Error (Missing_files paths) ->
+              print_error
+                (sprintf "Missing files containing the expected output: %s"
+                   (String.concat ", " (Fpath_.to_string_list paths)))
+          | Ok _expected_output -> (
+              match status.result with
+              | Error (Missing_files [ path ]) ->
+                  print_error
+                    (sprintf "Missing file containing the test output: %s"
+                       !!path)
+              | Error (Missing_files paths) ->
+                  print_error
+                    (sprintf "Missing files containing the test output: %s"
+                       (String.concat ", " (Fpath_.to_string_list paths)))
+              | Ok _ -> ()));
+          let capture_paths = Store.capture_paths_of_test test in
+          show_output_details test sum capture_paths;
+          let success = success_of_status_summary sum in
+          let show_unchecked_output =
+            always_show_unchecked_output
+            ||
+            match success with
+            | OK -> false
+            | OK_but_new -> true
+            | Not_OK _ -> true
+          in
+          (* TODO: show the checked output to be approved? *)
+          (if show_unchecked_output then
+             match Store.get_unchecked_output test with
+             | None -> (
+                 match success with
+                 | OK -> ()
+                 | OK_but_new -> ()
+                 | Not_OK (Some (Exception | Exception_and_wrong_output)) ->
+                     printf
+                       "%sFailed due to an exception. See captured output.\n"
+                       bullet
+                 | Not_OK (Some Wrong_output) ->
+                     printf "%sFailed due to wrong output.\n" bullet
+                 | Not_OK None ->
+                     printf
+                       "%sSucceded when it should have failed. See captured \
+                        output.\n"
+                       bullet)
+             | Some (log_description, data) -> (
+                 match data with
+                 | "" -> printf "%sLog (%s) is empty.\n" bullet log_description
+                 | _ ->
+                     printf "%sLog (%s):\n%s" bullet log_description
+                       (Style.quote_multiline_text data);
+                     if not (ends_with_newline data) then print_char '\n'));
+          (* Show the exception in case of a test failure due to an exception *)
+          if show_unchecked_output then
+            match success with
+            | Not_OK (Some (Exception | Exception_and_wrong_output)) -> (
+                match Store.get_exception test with
+                | Some msg ->
+                    printf "%sException raised by the test:\n%s" bullet
+                      (Style.color Red (Style.quote_multiline_text msg))
+                | None ->
+                    (* = assert false *)
+                    ())
+            | OK
+            | OK_but_new
+              when always_show_unchecked_output -> (
+                match Store.get_exception test with
+                | Some msg ->
+                    printf "%sException raised by the test:\n%s" bullet
+                      (Style.color Green (Style.quote_multiline_text msg))
+                | None -> ())
+            | OK
+            | OK_but_new
+            | Not_OK (Some Wrong_output)
+            | Not_OK None ->
+                ()));
   flush stdout
 
 let print_statuses ~highlight_test ~always_show_unchecked_output
@@ -607,7 +616,7 @@ let print_statuses ~highlight_test ~always_show_unchecked_output
 let is_overall_success statuses =
   statuses
   |> List.for_all (fun ((test : T.test), _status, sum) ->
-         test.skipped
+         test.skipped <> None
          ||
          match sum |> success_of_status_summary with
          | OK -> true
@@ -794,14 +803,16 @@ let run_tests_in_workers ~always_show_unchecked_output ~argv ~num_workers
         (match msg with
         | End_test test_id ->
             let test = get_test test_id in
-            if test.skipped then
-              printf "%s%s\n%!"
-                (Style.left_col (Style.color Yellow "[SKIP]"))
-                (format_title test)
-            else
-              get_test_with_status test
-              |> print_status ~highlight_test:false
-                   ~always_show_unchecked_output;
+            (match test.skipped with
+            | Some reason ->
+                printf "%s%s\n%!"
+                  (Style.left_col
+                     (Style.color Yellow (sprintf "[SKIP: %s] " reason)))
+                  (format_title test)
+            | None ->
+                get_test_with_status test
+                |> print_status ~highlight_test:false
+                     ~always_show_unchecked_output);
             feed_worker test_queue worker
         | Error msg ->
             eprintf "*** Internal error in worker %s: %s\n%!" worker_id msg;
@@ -839,14 +850,15 @@ let run_tests_sequentially ~always_show_unchecked_output (tests : T.test list) :
           test.func
       in
       previous >>= fun () ->
-      if test.skipped then (
-        report_skip_test test;
-        P.return ())
-      else (
-        report_start_test test;
-        P.catch test_func (fun _exn _trace -> P.return ()) >>= fun () ->
-        report_end_test ~always_show_unchecked_output test;
-        P.return ()))
+      match test.skipped with
+      | Some _reason ->
+          report_skip_test test;
+          P.return ()
+      | None ->
+          report_start_test test;
+          P.catch test_func (fun _exn _trace -> P.return ()) >>= fun () ->
+          report_end_test ~always_show_unchecked_output test;
+          P.return ())
     (P.return ()) tests
 
 let run_tests_requested_by_master (tests : T.test list) : 'unit_promise =
@@ -869,14 +881,15 @@ let run_tests_requested_by_master (tests : T.test list) : 'unit_promise =
             test.func
         in
         let job =
-          if test.skipped then (
-            (* This shouldn't happen but it's not a problem *)
-            Worker.Server.write (End_test test_id);
-            P.return ())
-          else
-            P.catch test_func (fun _exn _trace -> P.return ()) >>= fun () ->
-            Worker.Server.write (End_test test_id);
-            P.return ()
+          match test.skipped with
+          | Some _reason ->
+              (* This shouldn't happen but it's not a problem *)
+              Worker.Server.write (End_test test_id);
+              P.return ()
+          | None ->
+              P.catch test_func (fun _exn _trace -> P.return ()) >>= fun () ->
+              Worker.Server.write (End_test test_id);
+              P.return ()
         in
         loop job
   in

--- a/core/Testo.ml
+++ b/core/Testo.ml
@@ -91,7 +91,8 @@ type t = T.test = {
   tags : Tag.t list;
   normalize : (string -> string) list;
   checked_output : checked_output_kind;
-  skipped : bool;
+  skipped : string option;
+  solo : string option;
   tolerate_chdir : bool;
 }
 
@@ -139,7 +140,7 @@ let update_id (test : t) =
   { test with id; internal_full_name }
 
 let create ?(category = []) ?(checked_output = T.Ignore_output)
-    ?(expected_outcome = Should_succeed) ?(normalize = []) ?(skipped = false)
+    ?(expected_outcome = Should_succeed) ?(normalize = []) ?skipped ?solo
     ?(tags = []) ?(tolerate_chdir = false) name func =
   {
     id = "";
@@ -152,6 +153,7 @@ let create ?(category = []) ?(checked_output = T.Ignore_output)
     normalize;
     checked_output;
     skipped;
+    solo;
     tolerate_chdir;
   }
   |> update_id
@@ -159,7 +161,7 @@ let create ?(category = []) ?(checked_output = T.Ignore_output)
 let opt option default = Option.value option ~default
 
 let update ?category ?checked_output ?expected_outcome ?func ?normalize ?name
-    ?skipped ?tags ?tolerate_chdir old =
+    ?skipped ?solo ?tags ?tolerate_chdir old =
   {
     id = "";
     internal_full_name = "";
@@ -172,6 +174,7 @@ let update ?category ?checked_output ?expected_outcome ?func ?normalize ?name
     normalize = opt normalize old.normalize;
     checked_output = opt checked_output old.checked_output;
     skipped = opt skipped old.skipped;
+    solo = opt solo old.solo;
     tolerate_chdir = opt tolerate_chdir old.tolerate_chdir;
   }
   |> update_id
@@ -388,10 +391,10 @@ let to_alcotest = Run.to_alcotest
 let registered_tests : t list ref = ref []
 let register x = registered_tests := x :: !registered_tests
 
-let test ?category ?checked_output ?expected_outcome ?normalize ?skipped ?tags
-    ?tolerate_chdir name func =
-  create ?category ?checked_output ?expected_outcome ?normalize ?skipped ?tags
-    ?tolerate_chdir name func
+let test ?category ?checked_output ?expected_outcome ?normalize ?skipped ?solo
+    ?tags ?tolerate_chdir name func =
+  create ?category ?checked_output ?expected_outcome ?normalize ?skipped ?solo
+    ?tags ?tolerate_chdir name func
   |> register
 
 let get_registered_tests () = List.rev !registered_tests

--- a/core/Types.ml
+++ b/core/Types.ml
@@ -117,7 +117,8 @@ type test = {
   tags : Testo_util.Tag.t list;
   normalize : (string -> string) list;
   checked_output : checked_output_kind;
-  skipped : bool;
+  skipped : string option;
+  solo : string option;
   tolerate_chdir : bool;
 }
 

--- a/tests/Test.ml
+++ b/tests/Test.ml
@@ -377,6 +377,8 @@ let tests env =
         | Some "bar" -> ()
         | Some other ->
             Alcotest.fail (sprintf "Invalid value for variable foo: %S" other));
+    t "solo 1/2" (fun () -> Unix.sleepf 0.02) ~solo:"testing";
+    t "solo 2/2" (fun () -> Unix.sleepf 0.02) ~solo:"testing";
   ]
   @ categorized @ test_internal_files
   @ Testo.categorize "Slice"

--- a/tests/Test.ml
+++ b/tests/Test.ml
@@ -327,7 +327,8 @@ let tests env =
         | str -> printf "TESTO_TEST is set to %S.\n" str);
     t "xfail" ~expected_outcome:(Should_fail "raises exception on purpose")
       (fun () -> failwith "this exception is expected");
-    t "skipped" ~skipped:true (fun () -> failwith "this shouldn't happen");
+    t "skipped" ~skipped:"some reason" (fun () ->
+        failwith "this shouldn't happen");
     t "chdir" ~tolerate_chdir:true (fun () -> Sys.chdir "/");
     t ~checked_output:(Testo.stdout ()) ~normalize:[ String.lowercase_ascii ]
       "masked" (fun () -> print_endline "HELLO");

--- a/tests/snapshots/test-alcotest/7a153e9510c7/name
+++ b/tests/snapshots/test-alcotest/7a153e9510c7/name
@@ -1,1 +1,0 @@
-check stdout

--- a/tests/snapshots/test-alcotest/bf36d37e7d10/name
+++ b/tests/snapshots/test-alcotest/bf36d37e7d10/name
@@ -1,0 +1,1 @@
+check stdout (ignored by alcotest)

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -45,6 +45,8 @@ junk printed on stdout...
 [33m[MISS]  [0mafc104393bac [36mtemporary files[0m
 [33m[MISS]  [0m1f85f39d5e9a [36muser output capture[0m
 [33m[MISS]  [0mfb27e160e59b [36mrequire '--env foo=bar'[0m
+[33m[MISS]  [0m9213dcc500f4 [36msolo 1/2[0m
+[33m[MISS]  [0mb10dcbd5d4b9 [36msolo 2/2[0m
 [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [33m[MISS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
 [33m[MISS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m
@@ -81,6 +83,12 @@ Legend:
 [2m• [0m[xxxx*]: a new test for which there's no expected output yet.
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
+[33m[RUN SOLO: testing][0m 9213dcc500f4 [36msolo 1/2[0m
+[32m[PASS]  [0m9213dcc500f4 [36msolo 1/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/9213dcc500f4/log
+[33m[RUN SOLO: testing][0m b10dcbd5d4b9 [36msolo 2/2[0m
+[32m[PASS]  [0mb10dcbd5d4b9 [36msolo 2/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b10dcbd5d4b9/log
 [33m[RUN][0m   8dbdda48fb87 [36msimple[0m
 [worker 1/1] junk printed on stdout...
 [worker 1/1] ... when creating the test suite
@@ -159,7 +167,7 @@ Legend:
 [2m• [0mExpected to fail: raises exception on purpose
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/85349a4a9157/log
 [33m[RUN][0m   e52e279299e9 [36mskipped[0m
-[33m[SKIP: some reason] [0me52e279299e9 [36mskipped[0m
+[33m[SKIP: some reason][0m e52e279299e9 [36mskipped[0m
 [33m[RUN][0m   91a3c9030236 [36mchdir[0m
 [32m[PASS]  [0m91a3c9030236 [36mchdir[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/91a3c9030236/log
@@ -357,9 +365,9 @@ Legend:
 [2m• [0m[31mMissing file containing the expected output: tests/custom-snapshots/my-stdxxx[0m
 [2m• [0mPath to captured my-stdxxx: _build/testo/status/testo_tests/edebe706faa8/stdxxx
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[PASS*] [0md7f47c9a03b6 [36mauto-approve[0m > [36mcapture stdout and stderr in custom location[0m [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────────┘
+[2m┌───────────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[PASS*] [0md7f47c9a03b6 [36mauto-approve[0m > [36mcapture stdout and stderr in custom location[0m  [2m│[0m
+[2m└───────────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing files containing the expected output: tests/custom-snapshots/split-stdout, tests/custom-snapshots/split-stderr[0m
 [2m• [0mPath to captured split-stdout: _build/testo/status/testo_tests/d7f47c9a03b6/stdout
@@ -386,9 +394,9 @@ Legend:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-55/55 selected tests:
+57/57 selected tests:
   1 skipped
-  54 successful (53 pass, 1 xfail)
+  56 successful (55 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -521,6 +529,10 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/1f85f39d5e9a/log
 [32m[PASS]  [0mfb27e160e59b [36mrequire '--env foo=bar'[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/fb27e160e59b/log
+[32m[PASS]  [0m9213dcc500f4 [36msolo 1/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/9213dcc500f4/log
+[32m[PASS]  [0mb10dcbd5d4b9 [36msolo 2/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b10dcbd5d4b9/log
 [32m[PASS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
 [32m[PASS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
@@ -628,9 +640,9 @@ Legend:
 [2m• [0m[31mMissing file containing the expected output: tests/custom-snapshots/my-stdxxx[0m
 [2m• [0mPath to captured my-stdxxx: _build/testo/status/testo_tests/edebe706faa8/stdxxx
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[PASS*] [0md7f47c9a03b6 [36mauto-approve[0m > [36mcapture stdout and stderr in custom location[0m [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────────┘
+[2m┌───────────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[PASS*] [0md7f47c9a03b6 [36mauto-approve[0m > [36mcapture stdout and stderr in custom location[0m  [2m│[0m
+[2m└───────────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing files containing the expected output: tests/custom-snapshots/split-stdout, tests/custom-snapshots/split-stderr[0m
 [2m• [0mPath to captured split-stdout: _build/testo/status/testo_tests/d7f47c9a03b6/stdout
@@ -648,9 +660,9 @@ Legend:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-55/55 selected tests:
+57/57 selected tests:
   1 skipped
-  54 successful (53 pass, 1 xfail)
+  56 successful (55 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -752,7 +764,7 @@ Legend:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-1/55 selected tests:
+1/57 selected tests:
   0 successful (0 pass, 0 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [31mfailure[0m
@@ -781,7 +793,7 @@ Legend:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-1/55 selected tests:
+1/57 selected tests:
   1 successful (1 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m
@@ -931,6 +943,12 @@ Legend:
 [33m[MISS]  [0mfb27e160e59b [36mrequire '--env foo=bar'[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/fb27e160e59b/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/fb27e160e59b/log
+[33m[MISS]  [0m9213dcc500f4 [36msolo 1/2[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/9213dcc500f4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/9213dcc500f4/log
+[33m[MISS]  [0mb10dcbd5d4b9 [36msolo 2/2[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b10dcbd5d4b9/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b10dcbd5d4b9/log
 [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/33a93d234d01/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
@@ -1084,9 +1102,9 @@ Legend:
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/edebe706faa8/outcome[0m
 [2m• [0mPath to captured my-stdxxx: _build/testo/status/testo_tests/edebe706faa8/stdxxx
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0md7f47c9a03b6 [36mauto-approve[0m > [36mcapture stdout and stderr in custom location[0m [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────────┘
+[2m┌───────────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0md7f47c9a03b6 [36mauto-approve[0m > [36mcapture stdout and stderr in custom location[0m  [2m│[0m
+[2m└───────────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d7f47c9a03b6/outcome[0m
 [2m• [0mPath to captured split-stdout: _build/testo/status/testo_tests/d7f47c9a03b6/stdout
@@ -1222,6 +1240,18 @@ Legend:
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/fb27e160e59b/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m9213dcc500f4 [36msolo 1/2[0m                                                [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/9213dcc500f4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/9213dcc500f4/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mb10dcbd5d4b9 [36msolo 2/2[0m                                                [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b10dcbd5d4b9/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b10dcbd5d4b9/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m                               [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/33a93d234d01/outcome[0m
@@ -1253,9 +1283,9 @@ Legend:
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/caadabfd495c/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/caadabfd495c/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌────────────────────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m57b56cb8ada0 [36mauto-approve[0m > [36minternal files[0m > [36mcheck for name file in previous tests[0m [2m│[0m
-[2m└────────────────────────────────────────────────────────────────────────────────────────────┘
+[2m┌─────────────────────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m57b56cb8ada0 [36mauto-approve[0m > [36minternal files[0m > [36mcheck for name file in previous tests[0m  [2m│[0m
+[2m└─────────────────────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/57b56cb8ada0/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/57b56cb8ada0/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
@@ -1358,11 +1388,11 @@ Legend:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-55/55 selected tests:
+57/57 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-54 new tests
+56 new tests
 overall status: [31mfailure[0m
 <handling result before exiting>
 RUN ./test status -e foo=bar -l
@@ -1452,9 +1482,9 @@ junk printed on stdout...
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/edebe706faa8/outcome[0m
 [2m• [0mPath to captured my-stdxxx: _build/testo/status/testo_tests/edebe706faa8/stdxxx
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0md7f47c9a03b6 [36mauto-approve[0m > [36mcapture stdout and stderr in custom location[0m [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────────┘
+[2m┌───────────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0md7f47c9a03b6 [36mauto-approve[0m > [36mcapture stdout and stderr in custom location[0m  [2m│[0m
+[2m└───────────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d7f47c9a03b6/outcome[0m
 [2m• [0mPath to captured split-stdout: _build/testo/status/testo_tests/d7f47c9a03b6/stdout
@@ -1590,6 +1620,18 @@ junk printed on stdout...
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/fb27e160e59b/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m9213dcc500f4 [36msolo 1/2[0m                                                [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/9213dcc500f4/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/9213dcc500f4/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0mb10dcbd5d4b9 [36msolo 2/2[0m                                                [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b10dcbd5d4b9/outcome[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b10dcbd5d4b9/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m                               [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/33a93d234d01/outcome[0m
@@ -1621,9 +1663,9 @@ junk printed on stdout...
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/caadabfd495c/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/caadabfd495c/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌────────────────────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m57b56cb8ada0 [36mauto-approve[0m > [36minternal files[0m > [36mcheck for name file in previous tests[0m [2m│[0m
-[2m└────────────────────────────────────────────────────────────────────────────────────────────┘
+[2m┌─────────────────────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m57b56cb8ada0 [36mauto-approve[0m > [36minternal files[0m > [36mcheck for name file in previous tests[0m  [2m│[0m
+[2m└─────────────────────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/57b56cb8ada0/outcome[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/57b56cb8ada0/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
@@ -1726,11 +1768,11 @@ junk printed on stdout...
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-55/55 selected tests:
+57/57 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-54 new tests
+56 new tests
 overall status: [31mfailure[0m
 <handling result before exiting>
 RUN ./test status -e foo=bar -a
@@ -1769,6 +1811,8 @@ junk printed on stdout...
 [33m[MISS]  [0mafc104393bac [36mtemporary files[0m
 [33m[MISS]  [0m1f85f39d5e9a [36muser output capture[0m
 [33m[MISS]  [0mfb27e160e59b [36mrequire '--env foo=bar'[0m
+[33m[MISS]  [0m9213dcc500f4 [36msolo 1/2[0m
+[33m[MISS]  [0mb10dcbd5d4b9 [36msolo 2/2[0m
 [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [33m[MISS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
 [33m[MISS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m
@@ -1805,6 +1849,12 @@ Legend:
 [2m• [0m[xxxx*]: a new test for which there's no expected output yet.
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
+[33m[RUN SOLO: testing][0m 9213dcc500f4 [36msolo 1/2[0m
+[32m[PASS]  [0m9213dcc500f4 [36msolo 1/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/9213dcc500f4/log
+[33m[RUN SOLO: testing][0m b10dcbd5d4b9 [36msolo 2/2[0m
+[32m[PASS]  [0mb10dcbd5d4b9 [36msolo 2/2[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/b10dcbd5d4b9/log
 [33m[RUN][0m   8dbdda48fb87 [36msimple[0m
 [worker 1/1] junk printed on stdout...
 [worker 1/1] ... when creating the test suite
@@ -1881,7 +1931,7 @@ Legend:
 [2m• [0mExpected to fail: raises exception on purpose
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/85349a4a9157/log
 [33m[RUN][0m   e52e279299e9 [36mskipped[0m
-[33m[SKIP: some reason] [0me52e279299e9 [36mskipped[0m
+[33m[SKIP: some reason][0m e52e279299e9 [36mskipped[0m
 [33m[RUN][0m   91a3c9030236 [36mchdir[0m
 [32m[PASS]  [0m91a3c9030236 [36mchdir[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/91a3c9030236/log
@@ -2023,9 +2073,9 @@ Legend:
 2 folders no longer belong to the test suite and can be removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-55/55 selected tests:
+57/57 selected tests:
   1 skipped
-  54 successful (53 pass, 1 xfail)
+  56 successful (55 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m
 <handling result before exiting>

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -159,7 +159,7 @@ Legend:
 [2m• [0mExpected to fail: raises exception on purpose
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/85349a4a9157/log
 [33m[RUN][0m   e52e279299e9 [36mskipped[0m
-[33m[SKIP][0m  e52e279299e9 [36mskipped[0m
+[33m[SKIP: some reason] [0me52e279299e9 [36mskipped[0m
 [33m[RUN][0m   91a3c9030236 [36mchdir[0m
 [32m[PASS]  [0m91a3c9030236 [36mchdir[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/91a3c9030236/log
@@ -1881,7 +1881,7 @@ Legend:
 [2m• [0mExpected to fail: raises exception on purpose
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/85349a4a9157/log
 [33m[RUN][0m   e52e279299e9 [36mskipped[0m
-[33m[SKIP][0m  e52e279299e9 [36mskipped[0m
+[33m[SKIP: some reason] [0me52e279299e9 [36mskipped[0m
 [33m[RUN][0m   91a3c9030236 [36mchdir[0m
 [32m[PASS]  [0m91a3c9030236 [36mchdir[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/91a3c9030236/log

--- a/util/Style.ml
+++ b/util/Style.ml
@@ -49,7 +49,7 @@ let graph_length str = strip str |> utf8_length
 
 let pad str min_len =
   let len = graph_length str in
-  if len >= min_len then str else str ^ String.make (min_len - len) ' '
+  if len >= min_len then str ^ " " else str ^ String.make (min_len - len) ' '
 
 let left_col text = pad text 8
 


### PR DESCRIPTION
Closes #96 

We now also request a reason when skipping a test.

Closes #92 

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
