### PR TITLE
Fix CI environment

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,6 +29,7 @@ Python implementation.
 See https://github.com/paulgb/simplediff")
   (depends
     (ocaml (>= 4.08.0))
+    ppx_deriving
   )
 )
 
@@ -41,6 +42,7 @@ Testo is a test framework for OCaml.")
     (ocaml (>= 4.08.0))
     fpath
     (re (>= 1.10.0))
+    ppx_deriving
     testo-diff
   )
 )

--- a/scripts/dev-setup-alpine
+++ b/scripts/dev-setup-alpine
@@ -4,8 +4,9 @@
 #
 set -eu
 
-sudo apk add py3-pip
-pip install pre-commit
+# Use pipx instead of pip to avoid "error: externally-managed-environment"
+sudo apk add pipx
+pipx install pre-commit
 
 # hmmm
 src=$HOME/.local/bin/pre-commit

--- a/testo-diff.opam
+++ b/testo-diff.opam
@@ -15,6 +15,7 @@ bug-reports: "https://github.com/semgrep/testo/issues"
 depends: [
   "dune" {>= "3.7"}
   "ocaml" {>= "4.08.0"}
+  "ppx_deriving"
   "odoc" {with-doc}
 ]
 build: [

--- a/testo-util.opam
+++ b/testo-util.opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "fpath"
   "re" {>= "1.10.0"}
+  "ppx_deriving"
   "testo-diff"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
The CI checks hadn't run in 3 months since the semgrep organization changed how users log into GitHub. I re-enabled the CircleCI checks and found that they were failing. This PR fixes two errors:

* one problem with how `pre-commit` (a Python application) was installed;
* a missing opam dependency in the dune-project file and the derived opam files

The tests now pass for the legacy build (OCaml 4.08) and fail for OCaml 5.2.1. I'll fix this in another PR.

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
