### PR TITLE
Allow multiple '-s' substring search queries in the same command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
   complete but produces the incorrect output. Running the `approve`
   subcommand on such a test now successfully changes its status from
   XFAIL to XPASS ([#103](https://github.com/semgrep/testo/pull/103)).
+* Allow multiple `-s` search queries in the same test command,
+  allowing the selection of various tests by their name or hash
+  ([#110](https://github.com/semgrep/testo/pull/110)).
 
 0.1.0 (2024-11-10)
 ------------------

--- a/core/Run.ml
+++ b/core/Run.ml
@@ -394,8 +394,10 @@ let filter ~filter_by_substring ~filter_by_tag tests =
   let filter_sub =
     match filter_by_substring with
     | None -> None
-    | Some sub ->
-        let contains_sub = Helpers.contains_substring sub in
+    | Some subs ->
+        let contains_sub str =
+          List.exists (fun sub -> Helpers.contains_substring ~sub str) subs
+        in
         Some
           (fun (test : T.test) ->
             contains_sub test.internal_full_name || contains_sub test.id)

--- a/core/Run.mli
+++ b/core/Run.mli
@@ -21,7 +21,7 @@ val to_alcotest :
 val cmd_run :
   always_show_unchecked_output:bool ->
   argv:string array ->
-  filter_by_substring:string option ->
+  filter_by_substring:string list option ->
   filter_by_tag:Testo_util.Tag.t option ->
   is_worker:bool ->
   jobs:int option ->
@@ -38,7 +38,7 @@ val cmd_run :
    (PASS or XFAIL). *)
 val cmd_status :
   always_show_unchecked_output:bool ->
-  filter_by_substring:string option ->
+  filter_by_substring:string list option ->
   filter_by_tag:Testo_util.Tag.t option ->
   output_style:status_output_style ->
   strict:bool ->
@@ -46,7 +46,7 @@ val cmd_status :
   int * Types.test_with_status list
 
 val cmd_approve :
-  filter_by_substring:string option ->
+  filter_by_substring:string list option ->
   filter_by_tag:Testo_util.Tag.t option ->
   Types.test list ->
   int

--- a/tests/Meta_test.ml
+++ b/tests/Meta_test.ml
@@ -146,6 +146,18 @@ let test_standard_flow () =
   test_status ~__LOC__ "" ~expected_exit_code:1;
   test_approve ~__LOC__ "-s auto-approve"
 
+let test_multi_selection () =
+  let (), capture =
+    Testo.with_capture stdout (fun () ->
+      (* Select two tests that have different names. We could pick
+         any two tests for this. *)
+      shell_command ~__LOC__
+        "./test status -a -s 'unchecked stdout' -s 'unchecked stderr'"
+    )
+  in
+  assert (Testo_util.Helpers.contains_substring capture ~sub:"unchecked stdout");
+  assert (Testo_util.Helpers.contains_substring capture ~sub:"unchecked stderr")
+
 (*
    Invalid output -> XFAIL
    Approved output -> XPASS
@@ -258,6 +270,7 @@ let tests =
     t "approve xfail"
       ~checked_output:(T.stdxxx ())
       test_approve_xfail;
+    t "multi selection" test_multi_selection;
   ]
 
 let () =

--- a/util/lib/Helpers.ml
+++ b/util/lib/Helpers.ml
@@ -90,12 +90,12 @@ let rec remove_file_or_dir path =
     | S_SOCK ->
         Sys.remove !!path
 
-let contains_pcre_pattern pat =
+let contains_pcre_pattern ~pat =
   let rex = Re.Pcre.regexp pat in
   fun str -> Re.execp rex str
 
-let contains_substring substring =
-  contains_pcre_pattern (Re.Pcre.quote substring)
+let contains_substring ~sub =
+  contains_pcre_pattern ~pat:(Re.Pcre.quote sub)
 
 let write_file path data =
   let oc = open_out_bin !!path in

--- a/util/lib/Helpers.mli
+++ b/util/lib/Helpers.mli
@@ -22,7 +22,7 @@ val list_files : Fpath.t -> string list
 
 (* Delete files recursively *)
 val remove_file_or_dir : Fpath.t -> unit
-val contains_pcre_pattern : string -> string -> bool
-val contains_substring : string -> string -> bool
+val contains_pcre_pattern : pat:string -> string -> bool
+val contains_substring : sub:string -> string -> bool
 val write_file : Fpath.t -> string -> unit
 val read_file : Fpath.t -> string


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
