### PR TITLE
Hide legend with --expert

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 * Allow multiple `-s` search queries in the same test command,
   allowing the selection of various tests by their name or hash
   ([#110](https://github.com/semgrep/testo/pull/110)).
+* Add a `--expert` option to hide the legend printed by `run` and
+  `status` ([#109](https://github.com/semgrep/testo/issues/109)).
 
 0.1.0 (2024-11-10)
 ------------------

--- a/core/Cmd.ml
+++ b/core/Cmd.ml
@@ -307,6 +307,27 @@ let worker_term : bool Term.t =
 
 let run_doc = "run the tests"
 
+let run_man : Manpage.block list =
+  [
+    `S Manpage.s_description;
+    `P {|Run all or only some of the tests. By default, the status
+of each test is reported as they are executed. Here's the legend for test
+statuses:|};
+    `Pre "\
+• [PASS]: a successful test that was expected to succeed (good);
+• [FAIL]: a failing test that was expected to succeed (needs fixing);
+• [XFAIL]: a failing test that was expected to fail (tolerated failure);
+• [XPASS]: a successful test that was expected to fail (progress?).
+• [MISS]: a test that never ran;
+• [SKIP]: a test that is always skipped but kept around for some reason;
+• [xxxx*]: a new test for which there's no expected output yet.
+  In this case, you should review the test output and run the 'approve'
+  subcommand once you're satisfied with the output.
+";
+    `P {|To review the status of the tests without rerunning them,
+use the 'status' subcommand.|}
+  ]
+
 let optional_nonempty_list xs =
   match xs with
   | [] -> None
@@ -348,7 +369,7 @@ let subcmd_run_term ~argv ~default_workers (test_spec : _ test_spec) :
     $ verbose_run_term $ worker_term)
 
 let subcmd_run ~argv ~default_workers test_spec =
-  let info = Cmd.info "run" ~doc:run_doc in
+  let info = Cmd.info "run" ~doc:run_doc ~man:run_man in
   Cmd.v info (subcmd_run_term ~argv ~default_workers test_spec)
 
 (****************************************************************************)

--- a/core/Run.ml
+++ b/core/Run.ml
@@ -669,6 +669,7 @@ let print_status_introduction () =
 %s[xxxx*]: a new test for which there's no expected output yet.
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
+Try '--help' for options.
 |}
     bullet bullet bullet bullet bullet bullet bullet
 

--- a/core/Run.mli
+++ b/core/Run.mli
@@ -23,6 +23,7 @@ val cmd_run :
   argv:string array ->
   filter_by_substring:string list option ->
   filter_by_tag:Testo_util.Tag.t option ->
+  intro:string ->
   is_worker:bool ->
   jobs:int option ->
   lazy_:bool ->
@@ -40,6 +41,7 @@ val cmd_status :
   always_show_unchecked_output:bool ->
   filter_by_substring:string list option ->
   filter_by_tag:Testo_util.Tag.t option ->
+  intro:string ->
   output_style:status_output_style ->
   strict:bool ->
   Types.test list ->
@@ -50,3 +52,5 @@ val cmd_approve :
   filter_by_tag:Testo_util.Tag.t option ->
   Types.test list ->
   int
+
+val introduction_text : string

--- a/tests/Meta_test.ml
+++ b/tests/Meta_test.ml
@@ -123,6 +123,7 @@ let test_standard_flow () =
   test_approve ~__LOC__ "-s auto-approve";
   test_approve ~__LOC__ "-s environment-sensitive";
   test_status ~__LOC__ "";
+  test_status ~__LOC__ "--expert";
   test_status ~__LOC__ "--env A_b123=xxx";
   test_status ~__LOC__ "-e novalue" ~expected_exit_code:124;
   test_status ~__LOC__ "-e b@d_key=42" ~expected_exit_code:124;

--- a/tests/snapshots/testo_meta_tests/a1982e6b3f31/stdxxx
+++ b/tests/snapshots/testo_meta_tests/a1982e6b3f31/stdxxx
@@ -37,4 +37,5 @@
 8/8 selected tests:
 Legend:
 RUN ./parallel-test run -j4
+Try '--help' for options.
 overall status: [32msuccess[0m

--- a/tests/snapshots/testo_meta_tests/f69772f11d92/stdxxx
+++ b/tests/snapshots/testo_meta_tests/f69772f11d92/stdxxx
@@ -37,4 +37,5 @@
 8/8 selected tests:
 Legend:
 RUN ./parallel-test run -j100
+Try '--help' for options.
 overall status: [32msuccess[0m

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -869,6 +869,11 @@ junk printed on stdout...
 ... when creating the test suite
 [31m[FAIL]  [0m54ddc3c7d064 [36mbroken[0m
 <handling result before exiting>
+RUN ./test status -e foo=bar --expert
+junk printed on stdout...
+... when creating the test suite
+[31m[FAIL]  [0m54ddc3c7d064 [36mbroken[0m
+<handling result before exiting>
 RUN ./test status -e foo=bar --env A_b123=xxx
 junk printed on stdout...
 ... when creating the test suite

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -95,6 +95,7 @@ Legend:
 [2m• [0m[xxxx*]: a new test for which there's no expected output yet.
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
+Try '--help' for options.
 [33m[RUN SOLO: testing][0m 9213dcc500f4 [36msolo 1/2[0m
 [32m[PASS]  [0m9213dcc500f4 [36msolo 1/2[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/9213dcc500f4/log
@@ -512,6 +513,7 @@ Legend:
 [2m• [0m[xxxx*]: a new test for which there's no expected output yet.
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
+Try '--help' for options.
 
 [32m[PASS]  [0m8dbdda48fb87 [36msimple[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/8dbdda48fb87/log
@@ -905,6 +907,7 @@ Legend:
 [2m• [0m[xxxx*]: a new test for which there's no expected output yet.
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
+Try '--help' for options.
 [33m[RUN][0m   5eff5d8ffb2b [36menvironment-sensitive[0m
 [worker 1/1] junk printed on stdout...
 [worker 1/1] ... when creating the test suite
@@ -961,6 +964,7 @@ Legend:
 [2m• [0m[xxxx*]: a new test for which there's no expected output yet.
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
+Try '--help' for options.
 [33m[RUN][0m   5eff5d8ffb2b [36menvironment-sensitive[0m
 [worker 1/1] junk printed on stdout...
 [worker 1/1] ... when creating the test suite
@@ -994,6 +998,7 @@ Legend:
 [2m• [0m[xxxx*]: a new test for which there's no expected output yet.
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
+Try '--help' for options.
 
 [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8dbdda48fb87/completion_status[0m
@@ -2282,6 +2287,7 @@ Legend:
 [2m• [0m[xxxx*]: a new test for which there's no expected output yet.
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
+Try '--help' for options.
 [33m[RUN SOLO: testing][0m 9213dcc500f4 [36msolo 1/2[0m
 [32m[PASS]  [0m9213dcc500f4 [36msolo 1/2[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/9213dcc500f4/log


### PR DESCRIPTION
This PR adds an option `--expert` for not showing messages targeted at new users. The legend for the test statuses can be hidden with this option, resulting in more compact output. The test command can be aliased to `./test --expert` for everyday use.

I also added a line encouraging the user to consult `--help`.

See the discussion at #109 

Closes #109 

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
