### PR TITLE
Add _opam to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /_build
+/_opam
 
 # Symbolic links created dynamically
 /failing-test


### PR DESCRIPTION
I created a local switch for testo and saw that `_opam` appeared in my git diff. I've added it to `.gitignore`.

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
