### PR TITLE
fix(windows): don't catch sigpipe on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
+* Fix: don't set signals on Windows (https://github.com/semgrep/testo/pull/118).
 * Add `Testo.with_chdir` (https://github.com/semgrep/testo/pull/104).
 * Fix nonsensical diff formatting (https://github.com/semgrep/testo/pull/104).
 * Fix: enable the approval of the output of a test that is expected to

--- a/core/Cmd.ml
+++ b/core/Cmd.ml
@@ -84,7 +84,9 @@ let fatal_error msg =
      become empty. This closes the pipe connected to the worker's stdout.
 *)
 let ignore_broken_pipe () =
-  Sys.set_signal Sys.sigpipe (Signal_handle (fun _signal -> exit 0))
+  (* There are no signals to handle on Windows *)
+  if not Sys.win32 then
+    Sys.set_signal Sys.sigpipe (Signal_handle (fun _signal -> exit 0))
 
 let run_with_conf ((get_tests, handle_subcommand_result) : _ test_spec)
     (cmd_conf : cmd_conf) : unit =


### PR DESCRIPTION
When run on Windows, tests are liable to encounter tracebacks like

```
test.exe: internal error, uncaught exception:
          Invalid_argument("Sys.signal: unavailable signal")
          Raised by primitive operation at Stdlib__Sys.set_signal in file "sys.ml.in", line 82, characters 39-63
          Called from Testo__Cmd.run_with_conf in file "OSS/libs/testo/core/Cmd.ml", line 97, characters 29-50
          Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
          Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 35, characters 37-44
```

Because `Sys.signal` is not available on Windows.

Testing locally on my Windows VM has indicated that gating this on Windows allows tests to run correctly.

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
