### PR TITLE
fix(windows): make `with_redirect_fd_to_file` Windows compatible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+* Fix: handle temporary file deletion cleanly on windows
+  (https://github.com/semgrep/testo/pull/119)
 * Fix: don't set signals on Windows (https://github.com/semgrep/testo/pull/118).
 * Add `Testo.with_chdir` (https://github.com/semgrep/testo/pull/104).
 * Fix nonsensical diff formatting (https://github.com/semgrep/testo/pull/104).

--- a/core/Store.ml
+++ b/core/Store.ml
@@ -489,8 +489,8 @@ let with_redirect_fd_to_file fd filename func () =
       (* Open the file for writing only *)
       O_WRONLY;
       (* On Windows, allows deleting the file while it may be open. This matches
-         Linux and Max behavior and prevents specious permission errors if users
-         of this function try to delet [filename]. *)
+         POSIX behavior and prevents specious permission errors if users of this
+         function try to delete [filename]. *)
       O_SHARE_DELETE;
     ]
   in


### PR DESCRIPTION
The functions that use this combinator may try to delete the [filename]. In particular, this is done in [Temp_file.with_temp_file](https://github.com/semgrep/testo/blob/324883471634eba92b1d9608b298991bee3d67b4/core/Temp_file.ml#L9-L20). It is possible that some other part of the program maintaines a handle into the file when we call `Sys.remove`. This works without any problems on Linux and Mac, but on Windows it currently produces a permission error, such as

```
[10.14][ERROR]: Error: exception Error: Internal error in test framework: exception raised by 'finally': Sys_error("C:\\opam\\.cygwin\\root\\tmp\\testo-958f77.out: Permission denied")
Raised by primitive operation at Testo__Temp_file.with_temp_file.(fun) in file "OSS/libs/testo/core/Temp_file.ml", line 19, characters 26-43
Called from Testo__Monad.catch in file "OSS/libs/testo/core/Monad.ml", line 14, characters 6-13
```

To fix this, we here add `O_SHARE_DELETE` to the open_flags, which allows us to have the same behavior on Windows as on Linux and MacOS.


Tests:

No CI appears to be running in this repo yet, and adding that is out of scope for our work. However, I've opened a PR to update Semgrep with this change in https://github.com/semgrep/semgrep-proprietary/pull/3410. This validates that all existing CI jobs with tests build around Testo are still passing.

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan 
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.

---

cc @mjambon for review, when you have time. Thanks!