### PR TITLE
Add '--autoclean' option to delete dead snapshots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,10 @@
   ([#110](https://github.com/semgrep/testo/pull/110)).
 * Add a `--expert` option to hide the legend printed by `run` and
   `status` ([#109](https://github.com/semgrep/testo/issues/109)).
+* Add a `--autoclean` option to `run` and `status` subcommands to
+  delete test snapshots that don't belong to any known test as it
+  typically happens after tests are renamed
+  ([#126](https://github.com/semgrep/testo/pull/126)).
 
 0.1.0 (2024-11-10)
 ------------------

--- a/core/Run.mli
+++ b/core/Run.mli
@@ -21,6 +21,7 @@ val to_alcotest :
 val cmd_run :
   always_show_unchecked_output:bool ->
   argv:string array ->
+  autoclean:bool ->
   filter_by_substring:string list option ->
   filter_by_tag:Testo_util.Tag.t option ->
   intro:string ->
@@ -39,6 +40,7 @@ val cmd_run :
    (PASS or XFAIL). *)
 val cmd_status :
   always_show_unchecked_output:bool ->
+  autoclean:bool ->
   filter_by_substring:string list option ->
   filter_by_tag:Testo_util.Tag.t option ->
   intro:string ->

--- a/core/Store.ml
+++ b/core/Store.ml
@@ -450,6 +450,9 @@ let find_dead_snapshots tests : dead_snapshot list =
       else Some { dir_or_junk_file = dir; test_name })
     unknown_names
 
+let remove_dead_snapshot (x : dead_snapshot) =
+  Helpers.remove_file_or_dir x.dir_or_junk_file
+
 (**************************************************************************)
 (* Output redirection *)
 (**************************************************************************)

--- a/core/Store.mli
+++ b/core/Store.mli
@@ -111,6 +111,9 @@ type dead_snapshot = { dir_or_junk_file : Fpath.t; test_name : string option }
 *)
 val find_dead_snapshots : Types.test list -> dead_snapshot list
 
+(* Remove a snapshot folder *)
+val remove_dead_snapshot : dead_snapshot -> unit
+
 (**************************************************************************)
 (* User-facing utilities *)
 (**************************************************************************)

--- a/tests/Meta_test.ml
+++ b/tests/Meta_test.ml
@@ -148,7 +148,13 @@ let test_standard_flow () =
   section "Delete snapshots but not statuses";
   clear_snapshots ~__LOC__ ();
   test_status ~__LOC__ "" ~expected_exit_code:1;
-  test_approve ~__LOC__ "-s auto-approve"
+  test_approve ~__LOC__ "-s auto-approve";
+  section "Delete the dead snapshots with --autoclean";
+  test_status ~__LOC__ "-l --autoclean";
+  section "Check that the dead snapshots are gone";
+  test_status ~__LOC__ "-l";
+  section "Restore the dead snapshots";
+  shell_command ~__LOC__ "git restore tests/snapshots/testo_tests"
 
 let test_multi_selection () =
   let (), capture =

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -489,7 +489,7 @@ Try '--help' for options.
 [33m[PASS*] [0md7f47c9a03b6 [36mauto-approve[0m > [36mcapture stdout and stderr in custom location[0m
 [31m[FAIL]  [0m54ddc3c7d064 [36mbroken[0m
 [33m[PASS*] [0mf66d12950c64 [36mauto-approve[0m > [36minternal files[0m > [36mcreate name file[0m
-2 folders no longer belong to the test suite and can be removed:
+2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
 69/69 selected tests:
@@ -829,7 +829,7 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/f66d12950c64/log
 [2m• [0mLog (stderr) is empty.
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-2 folders no longer belong to the test suite and can be removed:
+2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
 69/69 selected tests:
@@ -948,7 +948,7 @@ Try '--help' for options.
 [2m• [0mLog (stderr) is empty.
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [31m[FAIL]  [0m5eff5d8ffb2b [36menvironment-sensitive[0m
-2 folders no longer belong to the test suite and can be removed:
+2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
 1/69 selected tests:
@@ -978,7 +978,7 @@ Try '--help' for options.
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/5eff5d8ffb2b/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/5eff5d8ffb2b/stdout
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/5eff5d8ffb2b/log
-2 folders no longer belong to the test suite and can be removed:
+2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
 1/69 selected tests:
@@ -1722,7 +1722,7 @@ Try '--help' for options.
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/74333515fe26/completion_status[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/74333515fe26/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-2 folders no longer belong to the test suite and can be removed:
+2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
 69/69 selected tests:
@@ -2195,7 +2195,7 @@ junk printed on stdout...
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/74333515fe26/completion_status[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/74333515fe26/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-2 folders no longer belong to the test suite and can be removed:
+2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
 69/69 selected tests:
@@ -2599,7 +2599,7 @@ Try '--help' for options.
  
 [0m[2m────────────────────────────────────────────────────────────────────────────────[0m
 [31m[FAIL]  [0m54ddc3c7d064 [36mbroken[0m
-2 folders no longer belong to the test suite and can be removed:
+2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
 69/69 selected tests:
@@ -2639,3 +2639,62 @@ junk printed on stdout...
 ... when creating the test suite
 Expected output changed for 9 tests.
 <handling result before exiting>
+#####################################################################
+# Delete the dead snapshots with --autoclean
+#####################################################################
+RUN ./test status -e foo=bar -l --autoclean
+junk printed on stdout...
+... when creating the test suite
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [31m[FAIL]  [0m54ddc3c7d064 [36mbroken[0m                                                  [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mThis test was marked as broken by the programmer: this test is super flaky
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/54ddc3c7d064/log
+[2m• [0mLog (stdout, stderr) is empty.
+[2m• [0mException raised by the test:
+[31m Failure("I am broken")
+ Raised at <MASKED>, line 29, characters 17-33
+ Called from <MASKED>
+ Called from <MASKED>
+ 
+[0m[2m────────────────────────────────────────────────────────────────────────────────[0m
+2 folders no longer belong to the test suite and are being removed:
+  tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
+  tests/snapshots/testo_tests/unnamed-junk ??
+69/69 selected tests:
+  1 skipped
+  67 successful (64 pass, 3 xfail)
+  1 unsuccessful (1 fail, 0 xpass)
+overall status: [32msuccess[0m
+[33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
+<handling result before exiting>
+#####################################################################
+# Check that the dead snapshots are gone
+#####################################################################
+RUN ./test status -e foo=bar -l
+junk printed on stdout...
+... when creating the test suite
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [31m[FAIL]  [0m54ddc3c7d064 [36mbroken[0m                                                  [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mThis test was marked as broken by the programmer: this test is super flaky
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/54ddc3c7d064/log
+[2m• [0mLog (stdout, stderr) is empty.
+[2m• [0mException raised by the test:
+[31m Failure("I am broken")
+ Raised at <MASKED>, line 29, characters 17-33
+ Called from <MASKED>
+ Called from <MASKED>
+ 
+[0m[2m────────────────────────────────────────────────────────────────────────────────[0m
+69/69 selected tests:
+  1 skipped
+  67 successful (64 pass, 3 xfail)
+  1 unsuccessful (1 fail, 0 xpass)
+overall status: [32msuccess[0m
+[33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
+<handling result before exiting>
+#####################################################################
+# Restore the dead snapshots
+#####################################################################
+RUN git restore tests/snapshots/testo_tests


### PR DESCRIPTION
`./test status --autoclean` or `./test run --autoclean` will delete snapshot folders that don't belong to any known test. This usually happens when a test is renamed or recategorized.

Closes #102 

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.
