### PR TITLE
Add types to support checked output files

### DIFF
--- a/core/Store.mli
+++ b/core/Store.mli
@@ -27,8 +27,6 @@ val init_workspace : unit -> unit
    for a test after applying all defaults and options.
 *)
 type capture_paths = {
-  (* Human-friendly name: "stdout", "stderr", or "stdxxx" *)
-  standard_name : string;
   (* Human-friendly name: "stdout" or the basename of user-specified file
      path. *)
   short_name : string;

--- a/core/Types.ml
+++ b/core/Types.ml
@@ -46,6 +46,23 @@ type passing_status =
   | XPASS
   | MISS of missing_files
 
+type checked_output_options = {
+  (* If specified, this is where the output file will be stored instead
+     of the default location. A relative path is recommended. *)
+  snapshot_path : Fpath.t option;
+}
+
+type checked_output_file = {
+  name : string; (* file identifier used for the copy of the output file and
+                    used by default as the snapshot file name *)
+  options : checked_output_options;
+}
+
+type checked_output_file_with_contents = {
+  checked_file : checked_output_file;
+  contents : string;
+}
+
 type captured_output =
   | Ignored of string (* unchecked combined output *)
   | Captured_stdout of string * string (* stdout, unchecked output *)
@@ -97,12 +114,6 @@ type status_summary = {
   has_expected_output : bool;
 }
 
-type checked_output_options = {
-  (* If specified, this is where the output file will be stored instead
-     of the default location. A relative path is recommended. *)
-  expected_output_path : Fpath.t option;
-}
-
 type checked_output_kind =
   | Ignore_output
   | Stdout of checked_output_options
@@ -126,6 +137,7 @@ type test = {
   (* Options (alphabetical order) *)
   broken : string option;
   checked_output : checked_output_kind;
+  checked_output_files : checked_output_file list;
   expected_outcome : expected_outcome;
   max_duration (* seconds *) : float option;
   normalize : (string -> string) list;

--- a/tests/Test.ml
+++ b/tests/Test.ml
@@ -20,6 +20,55 @@ let animal_tests = Testo.categorize "animal" [ t "banana slug" (fun () -> ()) ]
 let categorized =
   Testo.categorize_suites "biohazard" [ fruit_tests; animal_tests ]
 
+(*
+   Test the 'validate_name' function used by 'checked_output_file'.
+*)
+let test_checked_output_file_names () =
+  let invalid_names = [
+    "";
+    ".";
+    "..";
+    "a/b";
+    "a\\b";
+    "a:b";
+    " ";
+    "a b";
+    "a\nb";
+    "a\n";
+    "\na";
+    "+";
+    "a+b";
+    ".a";
+    "a.";
+  ] in
+  let valid_names = [
+    "a";
+    "A";
+    "aaa";
+    "AAA";
+    "_";
+    "___";
+    "-";
+    "---";
+    "a-b";
+    "a.b";
+    "3";
+    "333";
+    "ab.cd.ef";
+    "a..b";
+  ] in
+  List.iter (fun name ->
+    printf "Check that name is invalid: %S\n%!" name;
+    try
+      ignore (Testo.checked_output_file name);
+      Alcotest.fail "failed to raise Invalid_argument"
+    with Invalid_argument _ -> ()
+  ) invalid_names;
+  List.iter (fun name ->
+    printf "Check that name is valid: %S\n%!" name;
+    ignore (Testo.checked_output_file name)
+  ) valid_names
+
 let test_internal_files =
   let category = [ "auto-approve"; "internal files" ] in
   let test_create_name_file =
@@ -313,6 +362,7 @@ let tests env =
     t "simple" (fun () -> ());
     t "tags" ~tags:[ testing_tag; tags_tag ] (fun () -> ());
     t "category" ~category:[ "category"; "subcategory" ] (fun () -> ());
+    t "checked output file names" test_checked_output_file_names;
     t "unchecked stdout" (fun () -> print_endline "hello\nworld");
     t "unchecked stderr" (fun () -> prerr_string "hello\n");
     t "capture stdout" ~category:[ "auto-approve" ]

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -16,6 +16,7 @@ junk printed on stdout...
 [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m
 [33m[MISS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
 [33m[MISS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
+[33m[MISS]  [0ma885dcf169da [36mchecked output file names[0m
 [33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m
 [33m[MISS]  [0m68358d78cb0b [36munchecked stderr[0m
 [33m[MISS]  [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m
@@ -116,6 +117,9 @@ Try '--help' for options.
 [33m[RUN][0m   bd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
 [32m[PASS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/bd1c5167dc34/log
+[33m[RUN][0m   a885dcf169da [36mchecked output file names[0m
+[32m[PASS]  [0ma885dcf169da [36mchecked output file names[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a885dcf169da/log
 [33m[RUN][0m   2c57c8917bfb [36munchecked stdout[0m
 [32m[PASS]  [0m2c57c8917bfb [36munchecked stdout[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/2c57c8917bfb/log
@@ -498,9 +502,9 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-70/70 selected tests:
+71/71 selected tests:
   1 skipped
-  68 successful (65 pass, 3 xfail)
+  69 successful (66 pass, 3 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -527,6 +531,8 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/d57ac4525684/log
 [32m[PASS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/bd1c5167dc34/log
+[32m[PASS]  [0ma885dcf169da [36mchecked output file names[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a885dcf169da/log
 [32m[PASS]  [0m2c57c8917bfb [36munchecked stdout[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/2c57c8917bfb/log
 [32m[PASS]  [0m68358d78cb0b [36munchecked stderr[0m
@@ -842,9 +848,9 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-70/70 selected tests:
+71/71 selected tests:
   1 skipped
-  68 successful (65 pass, 3 xfail)
+  69 successful (66 pass, 3 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -961,7 +967,7 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-1/70 selected tests:
+1/71 selected tests:
   0 successful (0 pass, 0 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [31mfailure[0m
@@ -991,7 +997,7 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-1/70 selected tests:
+1/71 selected tests:
   1 successful (1 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m
@@ -1024,6 +1030,9 @@ Try '--help' for options.
 [33m[MISS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/bd1c5167dc34/completion_status[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/bd1c5167dc34/log
+[33m[MISS]  [0ma885dcf169da [36mchecked output file names[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/a885dcf169da/completion_status[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a885dcf169da/log
 [33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/2c57c8917bfb/completion_status[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/2c57c8917bfb/log
@@ -1297,6 +1306,12 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/bd1c5167dc34/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0ma885dcf169da [36mchecked output file names[0m                               [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/a885dcf169da/completion_status[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a885dcf169da/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m                                        [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/2c57c8917bfb/completion_status[0m
@@ -1748,11 +1763,11 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-70/70 selected tests:
+71/71 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-69 new tests
+70 new tests
 overall status: [31mfailure[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
 <handling result before exiting>
@@ -1778,6 +1793,12 @@ junk printed on stdout...
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/bd1c5167dc34/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0ma885dcf169da [36mchecked output file names[0m                               [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/a885dcf169da/completion_status[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a885dcf169da/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m                                        [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/2c57c8917bfb/completion_status[0m
@@ -2229,11 +2250,11 @@ junk printed on stdout...
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-70/70 selected tests:
+71/71 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-69 new tests
+70 new tests
 overall status: [31mfailure[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
 <handling result before exiting>
@@ -2243,6 +2264,7 @@ junk printed on stdout...
 [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m
 [33m[MISS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
 [33m[MISS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
+[33m[MISS]  [0ma885dcf169da [36mchecked output file names[0m
 [33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m
 [33m[MISS]  [0m68358d78cb0b [36munchecked stderr[0m
 [33m[MISS]  [0m9c96a5aa8b4b [36mauto-approve[0m > [36mcapture stdout[0m
@@ -2344,6 +2366,9 @@ Try '--help' for options.
 [33m[RUN][0m   bd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
 [32m[PASS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/bd1c5167dc34/log
+[33m[RUN][0m   a885dcf169da [36mchecked output file names[0m
+[32m[PASS]  [0ma885dcf169da [36mchecked output file names[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a885dcf169da/log
 [33m[RUN][0m   2c57c8917bfb [36munchecked stdout[0m
 [32m[PASS]  [0m2c57c8917bfb [36munchecked stdout[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/2c57c8917bfb/log
@@ -2639,9 +2664,9 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-70/70 selected tests:
+71/71 selected tests:
   1 skipped
-  68 successful (65 pass, 3 xfail)
+  69 successful (66 pass, 3 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [32msuccess[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
@@ -2698,9 +2723,9 @@ junk printed on stdout...
 2 folders no longer belong to the test suite and are being removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-70/70 selected tests:
+71/71 selected tests:
   1 skipped
-  68 successful (65 pass, 3 xfail)
+  69 successful (66 pass, 3 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [32msuccess[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
@@ -2724,9 +2749,9 @@ junk printed on stdout...
  Called from <MASKED>
  
 [0m[2m────────────────────────────────────────────────────────────────────────────────[0m
-70/70 selected tests:
+71/71 selected tests:
   1 skipped
-  68 successful (65 pass, 3 xfail)
+  69 successful (66 pass, 3 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [32msuccess[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m


### PR DESCRIPTION
This adds types and functions to the library's interface `Testo.mli`​ so as to support checked output files. `Testo.create`​ takes a new argument which ignored for now. The full implementation is done in subsequent PRs.

test plan: new unit test running as part of `make test`​

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.