### PR TITLE
Expose map_file and copy_file functions

### DIFF
--- a/core/Testo.ml
+++ b/core/Testo.ml
@@ -227,6 +227,15 @@ let fail = Testo_util.Error.fail_test
 
 let write_file = Helpers.write_file
 let read_file = Helpers.read_file
+
+let map_file func src_path dst_path =
+  let old_contents = read_file src_path in
+  let new_contents = func old_contents in
+  write_file dst_path new_contents
+
+let copy_file src_path dst_path =
+  map_file (fun data -> data) src_path dst_path
+
 let with_temp_file = Temp_file.with_temp_file
 let with_capture = Store.with_capture
 
@@ -473,6 +482,7 @@ let mask_not_substrings ?mask substrings =
     |> String.concat "|")
 
 let mask_not_substring ?mask substring = mask_not_substrings ?mask [ substring ]
+
 let has_tag tag test = List.mem tag test.tags
 
 let categorize name (tests : _ list) : _ list =

--- a/core/Testo.mli
+++ b/core/Testo.mli
@@ -337,7 +337,22 @@ val write_file : Fpath.t -> string -> unit
 *)
 
 val read_file : Fpath.t -> string
-(** Read the contents of a regular file. *)
+(** Read the contents of a regular file or symbolic link to a regular file. *)
+
+val map_file : (string -> string) -> Fpath.t -> Fpath.t -> unit
+(** [map_file func src dst] reads the contents of file (regular or symlink)
+    [src], applies [func] to its contents, and writes the result into
+    file [dst]. If file [dst] already exists, it is truncated and overwritten.
+    Otherwise, a regular file is created.
+    If [src] and [dst] represent the same file, [src] will be overwritten
+    with the new contents.
+*)
+
+val copy_file : Fpath.t -> Fpath.t -> unit
+(** Copy a file.
+    [copy_file src dst] is a shortcut for
+    [map_file (fun data -> data) src dst].
+*)
 
 val with_temp_file :
   ?contents:string ->

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -61,6 +61,8 @@ junk printed on stdout...
 [33m[MISS]  [0m8ae0ad03ce59 [36mdiff[0m > [36mjoined-context[0m
 [33m[MISS]  [0m360c4b690be4 [36mdiff[0m > [36mgap-in-context[0m
 [33m[MISS]  [0m08e4221951ee [36mcurrent test[0m
+[33m[MISS]  [0me06ba5b7f0ea [36mwrite/read/map file[0m
+[33m[MISS]  [0m76465929ce2f [36mwrite/read/map file in place[0m
 [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [33m[MISS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
 [33m[MISS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m
@@ -331,6 +333,12 @@ Try '--help' for options.
 [33m[RUN][0m   08e4221951ee [36mcurrent test[0m
 [32m[PASS]  [0m08e4221951ee [36mcurrent test[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/08e4221951ee/log
+[33m[RUN][0m   e06ba5b7f0ea [36mwrite/read/map file[0m
+[32m[PASS]  [0me06ba5b7f0ea [36mwrite/read/map file[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e06ba5b7f0ea/log
+[33m[RUN][0m   76465929ce2f [36mwrite/read/map file in place[0m
+[32m[PASS]  [0m76465929ce2f [36mwrite/read/map file in place[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/76465929ce2f/log
 [33m[RUN][0m   33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [32m[PASS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
@@ -502,9 +510,9 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-71/71 selected tests:
+73/73 selected tests:
   1 skipped
-  69 successful (66 pass, 3 xfail)
+  71 successful (68 pass, 3 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -708,6 +716,10 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/360c4b690be4/log
 [32m[PASS]  [0m08e4221951ee [36mcurrent test[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/08e4221951ee/log
+[32m[PASS]  [0me06ba5b7f0ea [36mwrite/read/map file[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e06ba5b7f0ea/log
+[32m[PASS]  [0m76465929ce2f [36mwrite/read/map file in place[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/76465929ce2f/log
 [32m[PASS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
 [32m[PASS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
@@ -848,9 +860,9 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-71/71 selected tests:
+73/73 selected tests:
   1 skipped
-  69 successful (66 pass, 3 xfail)
+  71 successful (68 pass, 3 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -967,7 +979,7 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-1/71 selected tests:
+1/73 selected tests:
   0 successful (0 pass, 0 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [31mfailure[0m
@@ -997,7 +1009,7 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-1/71 selected tests:
+1/73 selected tests:
   1 successful (1 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m
@@ -1218,6 +1230,12 @@ Try '--help' for options.
 [33m[MISS]  [0m08e4221951ee [36mcurrent test[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/08e4221951ee/completion_status[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/08e4221951ee/log
+[33m[MISS]  [0me06ba5b7f0ea [36mwrite/read/map file[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e06ba5b7f0ea/completion_status[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e06ba5b7f0ea/log
+[33m[MISS]  [0m76465929ce2f [36mwrite/read/map file in place[0m
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/76465929ce2f/completion_status[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/76465929ce2f/log
 [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/33a93d234d01/completion_status[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
@@ -1627,6 +1645,18 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/08e4221951ee/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0me06ba5b7f0ea [36mwrite/read/map file[0m                                     [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e06ba5b7f0ea/completion_status[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e06ba5b7f0ea/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m76465929ce2f [36mwrite/read/map file in place[0m                            [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/76465929ce2f/completion_status[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/76465929ce2f/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m                               [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/33a93d234d01/completion_status[0m
@@ -1763,11 +1793,11 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-71/71 selected tests:
+73/73 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-70 new tests
+72 new tests
 overall status: [31mfailure[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
 <handling result before exiting>
@@ -2114,6 +2144,18 @@ junk printed on stdout...
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/08e4221951ee/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0me06ba5b7f0ea [36mwrite/read/map file[0m                                     [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e06ba5b7f0ea/completion_status[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e06ba5b7f0ea/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m76465929ce2f [36mwrite/read/map file in place[0m                            [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/76465929ce2f/completion_status[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/76465929ce2f/log
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m                               [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/33a93d234d01/completion_status[0m
@@ -2250,11 +2292,11 @@ junk printed on stdout...
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-71/71 selected tests:
+73/73 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-70 new tests
+72 new tests
 overall status: [31mfailure[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
 <handling result before exiting>
@@ -2310,6 +2352,8 @@ junk printed on stdout...
 [33m[MISS]  [0m8ae0ad03ce59 [36mdiff[0m > [36mjoined-context[0m
 [33m[MISS]  [0m360c4b690be4 [36mdiff[0m > [36mgap-in-context[0m
 [33m[MISS]  [0m08e4221951ee [36mcurrent test[0m
+[33m[MISS]  [0me06ba5b7f0ea [36mwrite/read/map file[0m
+[33m[MISS]  [0m76465929ce2f [36mwrite/read/map file in place[0m
 [33m[MISS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [33m[MISS]  [0mec7514c8554d [36mbiohazard[0m > [36mfruit[0m > [36mkiwi[0m
 [33m[MISS]  [0mb8cd199f2e62 [36mbiohazard[0m > [36manimal[0m > [36mbanana slug[0m
@@ -2578,6 +2622,12 @@ Try '--help' for options.
 [33m[RUN][0m   08e4221951ee [36mcurrent test[0m
 [32m[PASS]  [0m08e4221951ee [36mcurrent test[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/08e4221951ee/log
+[33m[RUN][0m   e06ba5b7f0ea [36mwrite/read/map file[0m
+[32m[PASS]  [0me06ba5b7f0ea [36mwrite/read/map file[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/e06ba5b7f0ea/log
+[33m[RUN][0m   76465929ce2f [36mwrite/read/map file in place[0m
+[32m[PASS]  [0m76465929ce2f [36mwrite/read/map file in place[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/76465929ce2f/log
 [33m[RUN][0m   33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [32m[PASS]  [0m33a93d234d01 [36mbiohazard[0m > [36mfruit[0m > [36mapple[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/33a93d234d01/log
@@ -2664,9 +2714,9 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-71/71 selected tests:
+73/73 selected tests:
   1 skipped
-  69 successful (66 pass, 3 xfail)
+  71 successful (68 pass, 3 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [32msuccess[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
@@ -2723,9 +2773,9 @@ junk printed on stdout...
 2 folders no longer belong to the test suite and are being removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-71/71 selected tests:
+73/73 selected tests:
   1 skipped
-  69 successful (66 pass, 3 xfail)
+  71 successful (68 pass, 3 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [32msuccess[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
@@ -2749,9 +2799,9 @@ junk printed on stdout...
  Called from <MASKED>
  
 [0m[2m────────────────────────────────────────────────────────────────────────────────[0m
-71/71 selected tests:
+73/73 selected tests:
   1 skipped
-  69 successful (66 pass, 3 xfail)
+  71 successful (68 pass, 3 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [32msuccess[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m


### PR DESCRIPTION
These functions are provided to the user because they're useful when dealing with output files and other kinds of files. In particular, the `map_file`​ function makes it easy to blank out (normalize/mask) variable sections of output files if needed.

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.