### PR TITLE
Add option '--max-inline-log-bytes'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ x.x.x (xxxx-xx-xx)
 * Add an option `inline_logs` to create a test for which logs are
   always or never shown inline
   (https://github.com/semgrep/testo/issues/142).
+* Add a command-line option `--max-inline-log-bytes` to limit the size
+  of unchecked test output (logs) shown inline when reporting the
+  status of a test. The default limit is 1MB
+  (https://github.com/semgrep/testo/issues/144).
 
 0.2.0 (2025-09-11)
 ------------------

--- a/core/Run.ml
+++ b/core/Run.ml
@@ -542,7 +542,9 @@ let ends_with_newline str =
   *)
   str <> "" && str.[String.length str - 1] = '\n'
 
-let print_status ~highlight_test ~always_show_unchecked_output
+let print_status ~highlight_test
+    ~always_show_unchecked_output:(always_show_unchecked_output,
+                                   max_inline_log_bytes)
     (((test : T.test), (status : T.status), sum) as test_with_status) =
   let title = format_one_line_status test_with_status in
   with_highlight_test ~highlight_test ~title (fun () ->
@@ -713,7 +715,9 @@ let print_status ~highlight_test ~always_show_unchecked_output
                  | "" -> printf "%sLog (%s) is empty.\n" bullet log_description
                  | _ ->
                      printf "%sLog (%s):\n%s" bullet log_description
-                       (Style.quote_multiline_text data);
+                       (Style.quote_multiline_text
+                          ?max_bytes:max_inline_log_bytes
+                          data);
                      if not (ends_with_newline data) then print_char '\n'));
           (* Show the exception in case of a test failure due to an exception *)
           if show_unchecked_output then
@@ -722,7 +726,9 @@ let print_status ~highlight_test ~always_show_unchecked_output
                 match Store.get_exception test with
                 | Some msg ->
                     printf "%sException raised by the test:\n%s" bullet
-                      (Style.color Red (Style.quote_multiline_text msg))
+                      (Style.quote_multiline_text
+                         ~decorate_data_fragment:(Style.color Red)
+                         msg)
                 | None ->
                     (* = assert false *)
                     ())
@@ -734,7 +740,9 @@ let print_status ~highlight_test ~always_show_unchecked_output
                 match Store.get_exception test with
                 | Some msg ->
                     printf "%sException raised by the test:\n%s" bullet
-                      (Style.color Green (Style.quote_multiline_text msg))
+                      (Style.quote_multiline_text
+                         ~decorate_data_fragment:(Style.color Green)
+                         msg)
                 | None -> ())
             | OK
             | OK_but_new

--- a/core/Run.mli
+++ b/core/Run.mli
@@ -19,7 +19,7 @@ val to_alcotest :
   alcotest_skip:(unit -> _) -> Types.test list -> alcotest_test list
 
 val cmd_run :
-  always_show_unchecked_output:bool ->
+  always_show_unchecked_output:(bool * int option) ->
   argv:string array ->
   autoclean:bool ->
   filter_by_substring:string list option ->
@@ -39,7 +39,7 @@ val cmd_run :
    Return a non-zero exit status if any of the tests is not a success
    (PASS or XFAIL). *)
 val cmd_status :
-  always_show_unchecked_output:bool ->
+  always_show_unchecked_output:(bool * int option) ->
   autoclean:bool ->
   filter_by_substring:string list option ->
   filter_by_tag:Testo_util.Tag.t option ->

--- a/tests/Meta_test.ml
+++ b/tests/Meta_test.ml
@@ -21,7 +21,7 @@ let t = T.create
 *)
 let shell_command ?(expected_exit_code = 0) ~__LOC__:loc command =
   printf "RUN %s\n%!" command;
-  let bash_command = sprintf "bash -c '%s'" command in
+  let bash_command = sprintf "bash -c \"%s\"" command in
   let exit_code = Sys.command bash_command in
   if exit_code <> expected_exit_code then
     failwith
@@ -227,6 +227,10 @@ let test_updated_output_file_capture () =
       shell_command ~__LOC__ "git restore tests/snapshots/testo_tests"
     )
 
+let test_max_inline_log_size ~limit () =
+  test_run ~__LOC__ (sprintf
+                       "-s 'inline logs' --max-inline-log-bytes %s" limit)
+
 (*****************************************************************************)
 (* Exercise the parallel test suite *)
 (*****************************************************************************)
@@ -359,6 +363,12 @@ let tests =
     t "multi selection" test_multi_selection;
     t "new output file capture" test_new_output_file_capture;
     t "updated output file capture" test_updated_output_file_capture;
+    t "max inline log size"
+      ~checked_output:(T.stdout ())
+      (test_max_inline_log_size ~limit:"5");
+    t "no max inline log size"
+      ~checked_output:(T.stdout ())
+      (test_max_inline_log_size ~limit:"unlimited");
   ]
 
 let () =

--- a/tests/snapshots/testo_meta_tests/09a1af4a20b0/name
+++ b/tests/snapshots/testo_meta_tests/09a1af4a20b0/name
@@ -1,0 +1,1 @@
+max inline log size

--- a/tests/snapshots/testo_meta_tests/09a1af4a20b0/stdout
+++ b/tests/snapshots/testo_meta_tests/09a1af4a20b0/stdout
@@ -1,0 +1,39 @@
+RUN ./test run -e foo=bar -j 1 -s 'inline logs' --max-inline-log-bytes 5
+junk printed on stdout...
+... when creating the test suite
+Legend:
+[2m• [0m[PASS]: a successful test that was expected to succeed (good);
+[2m• [0m[FAIL]: a failing test that was expected to succeed (needs fixing);
+[2m• [0m[XFAIL]: a failing test that was expected to fail (tolerated failure);
+[2m• [0m[XPASS]: a successful test that was expected to fail (progress?).
+[2m• [0m[MISS]: a test that never ran;
+[2m• [0m[SKIP]: a test that is always skipped but kept around for some reason;
+[2m• [0m[xxxx*]: a new test for which there's no expected output yet.
+  In this case, you should review the test output and run the 'approve'
+  subcommand once you're satisfied with the output.
+Try '--help' for options.
+[33m[RUN][0m   57fbfca04c25 [36minline logs[0m
+[worker 1/1] junk printed on stdout...
+[worker 1/1] ... when creating the test suite
+[32m[PASS]  [0m57fbfca04c25 [36minline logs[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/57fbfca04c25/log
+[2m• [0mLog (stdout, stderr):
+ [33m###### Warning: bytes 2-18 below were elided ######
+ [0mHe[33m
+ ###### [hidden: 17 bytes] ######
+ [0mg.
+ 
+[33m[RUN][0m   9c3540949276 [36mauto inline logs[0m
+[32m[PASS]  [0m9c3540949276 [36mauto inline logs[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/9c3540949276/log
+[33m[RUN][0m   33c81575317c [36mno inline logs[0m
+[32m[PASS]  [0m33c81575317c [36mno inline logs[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/33c81575317c/log
+2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
+  tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
+  tests/snapshots/testo_tests/unnamed-junk ??
+3/81 selected tests:
+  3 successful (3 pass, 0 xfail)
+  0 unsuccessful (0 fail, 0 xpass)
+overall status: [32msuccess[0m
+<handling result before exiting>

--- a/tests/snapshots/testo_meta_tests/b44050392a05/name
+++ b/tests/snapshots/testo_meta_tests/b44050392a05/name
@@ -1,0 +1,1 @@
+no max inline log size

--- a/tests/snapshots/testo_meta_tests/b44050392a05/stdout
+++ b/tests/snapshots/testo_meta_tests/b44050392a05/stdout
@@ -1,0 +1,36 @@
+RUN ./test run -e foo=bar -j 1 -s 'inline logs' --max-inline-log-bytes unlimited
+junk printed on stdout...
+... when creating the test suite
+Legend:
+[2m• [0m[PASS]: a successful test that was expected to succeed (good);
+[2m• [0m[FAIL]: a failing test that was expected to succeed (needs fixing);
+[2m• [0m[XFAIL]: a failing test that was expected to fail (tolerated failure);
+[2m• [0m[XPASS]: a successful test that was expected to fail (progress?).
+[2m• [0m[MISS]: a test that never ran;
+[2m• [0m[SKIP]: a test that is always skipped but kept around for some reason;
+[2m• [0m[xxxx*]: a new test for which there's no expected output yet.
+  In this case, you should review the test output and run the 'approve'
+  subcommand once you're satisfied with the output.
+Try '--help' for options.
+[33m[RUN][0m   57fbfca04c25 [36minline logs[0m
+[worker 1/1] junk printed on stdout...
+[worker 1/1] ... when creating the test suite
+[32m[PASS]  [0m57fbfca04c25 [36minline logs[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/57fbfca04c25/log
+[2m• [0mLog (stdout, stderr):
+ Hello. This is a log.
+ 
+[33m[RUN][0m   9c3540949276 [36mauto inline logs[0m
+[32m[PASS]  [0m9c3540949276 [36mauto inline logs[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/9c3540949276/log
+[33m[RUN][0m   33c81575317c [36mno inline logs[0m
+[32m[PASS]  [0m33c81575317c [36mno inline logs[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/33c81575317c/log
+2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
+  tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
+  tests/snapshots/testo_tests/unnamed-junk ??
+3/81 selected tests:
+  3 successful (3 pass, 0 xfail)
+  0 unsuccessful (0 fail, 0 xpass)
+overall status: [32msuccess[0m
+<handling result before exiting>

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -221,12 +221,12 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/c86c9fc3ac85/log
 [2m• [0mLog (stdout, stderr) is empty.
 [2m• [0mException raised by the test:
-[32m Failure("This exception was raised on purpose")
+ Failure("This exception was raised on purpose")
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
  
-[0m[33m[RUN][0m   0ac34585feff [36mauto show exception on xfail[0m
+[33m[RUN][0m   0ac34585feff [36mauto show exception on xfail[0m
 [32m[XFAIL] [0m0ac34585feff [36mauto show exception on xfail[0m
 [2m• [0mExpected to fail: raises Failure exception on purpose
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/0ac34585feff/log
@@ -259,12 +259,12 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/54ddc3c7d064/log
 [2m• [0mLog (stdout, stderr) is empty.
 [2m• [0mException raised by the test:
-[31m Failure("I am broken")
+ Failure("I am broken")
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
  
-[0m[33m[RUN][0m   a55170a13733 [36mtracking URL[0m
+[33m[RUN][0m   a55170a13733 [36mtracking URL[0m
 [32m[PASS]  [0ma55170a13733 [36mtracking URL[0m
 [2m• [0mTracking URL: https://example.com/issue/1234
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/a55170a13733/log
@@ -538,12 +538,12 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/54ddc3c7d064/log
 [2m• [0mLog (stdout, stderr) is empty.
 [2m• [0mException raised by the test:
-[31m Failure("I am broken")
+ Failure("I am broken")
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
  
-[0m[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0mf66d12950c64 [36mauto-approve[0m > [36minternal files[0m > [36mcreate name file[0m        [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
@@ -672,12 +672,12 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/c86c9fc3ac85/log
 [2m• [0mLog (stdout, stderr) is empty.
 [2m• [0mException raised by the test:
-[32m Failure("This exception was raised on purpose")
+ Failure("This exception was raised on purpose")
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
  
-[0m[32m[XFAIL] [0m0ac34585feff [36mauto show exception on xfail[0m
+[32m[XFAIL] [0m0ac34585feff [36mauto show exception on xfail[0m
 [2m• [0mExpected to fail: raises Failure exception on purpose
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/0ac34585feff/log
 [32m[XFAIL] [0md01c1bdbafaa [36mdon't show exception on xfail[0m
@@ -704,12 +704,12 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/54ddc3c7d064/log
 [2m• [0mLog (stdout, stderr) is empty.
 [2m• [0mException raised by the test:
-[31m Failure("I am broken")
+ Failure("I am broken")
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
  
-[0m[32m[PASS]  [0ma55170a13733 [36mtracking URL[0m
+[32m[PASS]  [0ma55170a13733 [36mtracking URL[0m
 [2m• [0mTracking URL: https://example.com/issue/1234
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/a55170a13733/log
 [32m[PASS]  [0m91a3c9030236 [36mchdir[0m
@@ -938,12 +938,12 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/54ddc3c7d064/log
 [2m• [0mLog (stdout, stderr) is empty.
 [2m• [0mException raised by the test:
-[31m Failure("I am broken")
+ Failure("I am broken")
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
  
-[0m[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0mf66d12950c64 [36mauto-approve[0m > [36minternal files[0m > [36mcreate name file[0m        [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
@@ -2756,12 +2756,12 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/c86c9fc3ac85/log
 [2m• [0mLog (stdout, stderr) is empty.
 [2m• [0mException raised by the test:
-[32m Failure("This exception was raised on purpose")
+ Failure("This exception was raised on purpose")
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
  
-[0m[33m[RUN][0m   0ac34585feff [36mauto show exception on xfail[0m
+[33m[RUN][0m   0ac34585feff [36mauto show exception on xfail[0m
 [32m[XFAIL] [0m0ac34585feff [36mauto show exception on xfail[0m
 [2m• [0mExpected to fail: raises Failure exception on purpose
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/0ac34585feff/log
@@ -2794,12 +2794,12 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/54ddc3c7d064/log
 [2m• [0mLog (stdout, stderr) is empty.
 [2m• [0mException raised by the test:
-[31m Failure("I am broken")
+ Failure("I am broken")
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
  
-[0m[33m[RUN][0m   a55170a13733 [36mtracking URL[0m
+[33m[RUN][0m   a55170a13733 [36mtracking URL[0m
 [32m[PASS]  [0ma55170a13733 [36mtracking URL[0m
 [2m• [0mTracking URL: https://example.com/issue/1234
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/a55170a13733/log
@@ -3006,12 +3006,12 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/54ddc3c7d064/log
 [2m• [0mLog (stdout, stderr) is empty.
 [2m• [0mException raised by the test:
-[31m Failure("I am broken")
+ Failure("I am broken")
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
  
-[0m[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m────────────────────────────────────────────────────────────────────────────────[0m
 [31m[FAIL]  [0m54ddc3c7d064 [36mbroken[0m
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
@@ -3066,12 +3066,12 @@ junk printed on stdout...
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/54ddc3c7d064/log
 [2m• [0mLog (stdout, stderr) is empty.
 [2m• [0mException raised by the test:
-[31m Failure("I am broken")
+ Failure("I am broken")
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
  
-[0m[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m────────────────────────────────────────────────────────────────────────────────[0m
 2 folders no longer belong to the test suite and are being removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
@@ -3095,12 +3095,12 @@ junk printed on stdout...
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/54ddc3c7d064/log
 [2m• [0mLog (stdout, stderr) is empty.
 [2m• [0mException raised by the test:
-[31m Failure("I am broken")
+ Failure("I am broken")
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
  
-[0m[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m────────────────────────────────────────────────────────────────────────────────[0m
 81/81 selected tests:
   1 skipped
   79 successful (73 pass, 6 xfail)

--- a/util/lib/Style.mli
+++ b/util/lib/Style.mli
@@ -28,7 +28,14 @@ val left_col : string -> string
 (*
    Print multiline text with an indentation. Always adds a trailing newline.
 
+   The midsection is elided if the input string exceeds 'max_bytes'.
+   Data fragments can be highlighted in a different color than the
+   text we insert to signal the elision.
+
    Pros: disambiguates the quoted text from other output
    Cons: interferes with proper copy-pasting (since it inserts whitespace)
 *)
-val quote_multiline_text : string -> string
+val quote_multiline_text :
+  ?decorate_comment:(string -> string) ->
+  ?decorate_data_fragment:(string -> string) ->
+  ?max_bytes:int -> string -> string


### PR DESCRIPTION
Closes https://github.com/semgrep/testo/issues/144

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.