### PR TITLE
Don't print '.orig' when not applicable

### DIFF
--- a/core/Run.ml
+++ b/core/Run.ml
@@ -496,7 +496,7 @@ let show_output_details (test : T.test) (sum : T.status_summary)
   capture_paths
   |> List.iter
        (fun
-         ({ short_name; path_to_expected_output; path_to_output; _ } :
+         ({ kind; short_name; path_to_expected_output; path_to_output } :
            Store.capture_paths)
        ->
          (* TODO: why do we flush stdout and stderr here? *)
@@ -516,9 +516,10 @@ let show_output_details (test : T.test) (sum : T.status_summary)
                  !!path_to_expected_output);
          printf "%sPath to captured %s: %s%s\n" bullet short_name
            !!path_to_output
-           (match Store.get_orig_output_suffix test with
-           | Some suffix -> sprintf " [%s]" suffix
-           | None -> ""))
+           (match Store.get_orig_output_suffix test, kind with
+           | Some suffix, Std -> sprintf " [%s]" suffix
+           | None, _
+           | Some _, (Log | File) -> ""))
 
 let print_error text = printf "%s%s\n" bullet (Style.color Red text)
 

--- a/core/Store.ml
+++ b/core/Store.ml
@@ -33,9 +33,12 @@ module P = Promise
    that all library authors should be able to use.
 *)
 
+type capture_kind = Std | File | Log
+
 (* All the data we need to handle the files that contain the captured output
    for a test after applying all defaults and options. *)
 type capture_paths = {
+  kind : capture_kind;
   (* Human-friendly name: "stdout" or the basename of user-specified file
      path. *)
   short_name : string;
@@ -339,6 +342,7 @@ let get_exception (test : T.test) =
 let std_capture_paths_of_test (test : T.test) : capture_paths list =
   let unchecked_paths =
     {
+      kind = Log;
       short_name = unchecked_filename;
       path_to_expected_output = None;
       path_to_output = get_std_output_path test unchecked_filename;
@@ -349,6 +353,7 @@ let std_capture_paths_of_test (test : T.test) : capture_paths list =
   | Stdout options ->
       [
         {
+          kind = Std;
           short_name =
             short_name_of_checked_output_options stdout_filename options;
           path_to_expected_output =
@@ -360,6 +365,7 @@ let std_capture_paths_of_test (test : T.test) : capture_paths list =
   | Stderr options ->
       [
         {
+          kind = Std;
           short_name =
             short_name_of_checked_output_options stderr_filename options;
           path_to_expected_output =
@@ -371,6 +377,7 @@ let std_capture_paths_of_test (test : T.test) : capture_paths list =
   | Stdxxx options ->
       [
         {
+          kind = Std;
           short_name =
             short_name_of_checked_output_options stdxxx_filename options;
           path_to_expected_output =
@@ -381,6 +388,7 @@ let std_capture_paths_of_test (test : T.test) : capture_paths list =
   | Split_stdout_stderr (stdout_options, stderr_options) ->
       [
         {
+          kind = Std;
           short_name =
             short_name_of_checked_output_options stdout_filename stdout_options;
           path_to_expected_output =
@@ -388,6 +396,7 @@ let std_capture_paths_of_test (test : T.test) : capture_paths list =
           path_to_output = get_std_output_path test stdout_filename;
         };
         {
+          kind = Std;
           short_name =
             short_name_of_checked_output_options stderr_filename stderr_options;
           path_to_expected_output =
@@ -400,6 +409,7 @@ let file_capture_paths_of_test (test : T.test) : capture_paths list =
   test.checked_output_files
   |> Helpers.list_map (fun (x : T.checked_output_file) ->
     {
+      kind = File;
       short_name = x.name;
       path_to_expected_output = Some (get_file_snapshot_path test x);
       path_to_output = get_output_file_path test x;

--- a/core/Store.mli
+++ b/core/Store.mli
@@ -32,10 +32,18 @@ val init_workspace : unit -> unit
 val init_test_workspace : Types.test -> unit
 
 (*
+   Std: checked output (stdout and/or stderr)
+   File: checked output file
+   Log: unchecked output
+*)
+type capture_kind = Std | File | Log
+
+(*
    All the data we need to handle the files that contain the captured output
    for a test after applying all defaults and options.
 *)
 type capture_paths = {
+  kind : capture_kind;
   (* Human-friendly name: "stdout" or the basename of user-specified file
      path. *)
   short_name : string;
@@ -115,6 +123,8 @@ val approve_new_output : Types.test -> (changed, string) Result.t
 (*
    If a test is configured to normalize its output, this returns the
    suffix for the backup file holding the original captured output.
+   This is only for stdout/stderr checked output, not for
+   checked output files.
 *)
 val get_orig_output_suffix : Types.test -> string option
 

--- a/tests/Test.ml
+++ b/tests/Test.ml
@@ -456,6 +456,7 @@ let tests env =
          )
       );
     t "capture multiple files and stdout"
+      ~normalize:[(fun s -> "[normalized] " ^ s)]
       ~checked_output:(Testo.stdout ())
       ~checked_output_files:[
         Testo.checked_output_file "results.txt";

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -197,7 +197,7 @@ Try '--help' for options.
 [2m• [0mChecked output: stdout
 [2m• [0mChecked output files: results.txt, results.json
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/0658581e95c7/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/0658581e95c7/stdout
+[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/0658581e95c7/stdout [.orig]
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/0658581e95c7/log
 [2m• [0mPath to expected results.txt: tests/snapshots/testo_tests/0658581e95c7/file-results.txt
 [2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/0658581e95c7/file-results.txt
@@ -283,7 +283,7 @@ Try '--help' for options.
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/a3e1a604f579/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/a3e1a604f579/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log
 [33m[RUN][0m   3b24997d50c8 [36mmask_pcre_pattern[0m
 [32m[PASS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
@@ -313,25 +313,25 @@ Try '--help' for options.
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/d5b0041ea8f4/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log
 [33m[RUN][0m   99746f633129 [36mcheck words in stdout[0m
 [32m[PASS]  [0m99746f633129 [36mcheck words in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/99746f633129/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/99746f633129/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log
 [33m[RUN][0m   7e7e7c09bfff [36mcheck for substrings in stdout[0m
 [32m[PASS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/7e7e7c09bfff/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/7e7e7c09bfff/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log
 [33m[RUN][0m   065cc54b852b [36malcotest error formatting[0m
 [32m[PASS]  [0m065cc54b852b [36malcotest error formatting[0m
 [2m• [0mChecked output: stderr
 [2m• [0mPath to expected stderr: tests/snapshots/testo_tests/065cc54b852b/stderr
 [2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
 [33m[RUN][0m   afc104393bac [36mtemporary files[0m
 [32m[PASS]  [0mafc104393bac [36mtemporary files[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/afc104393bac/log
@@ -652,7 +652,7 @@ Try '--help' for options.
 [2m• [0mChecked output: stdout
 [2m• [0mChecked output files: results.txt, results.json
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/0658581e95c7/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/0658581e95c7/stdout
+[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/0658581e95c7/stdout [.orig]
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/0658581e95c7/log
 [2m• [0mPath to expected results.txt: tests/snapshots/testo_tests/0658581e95c7/file-results.txt
 [2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/0658581e95c7/file-results.txt
@@ -723,7 +723,7 @@ Try '--help' for options.
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/a3e1a604f579/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/a3e1a604f579/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log
 [32m[PASS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
 [32m[PASS]  [0me8a3ba3cf9b4 [36mmask_temp_paths[0m
@@ -744,22 +744,22 @@ Try '--help' for options.
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/d5b0041ea8f4/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log
 [32m[PASS]  [0m99746f633129 [36mcheck words in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/99746f633129/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/99746f633129/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log
 [32m[PASS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/7e7e7c09bfff/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/7e7e7c09bfff/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log
 [32m[PASS]  [0m065cc54b852b [36malcotest error formatting[0m
 [2m• [0mChecked output: stderr
 [2m• [0mPath to expected stderr: tests/snapshots/testo_tests/065cc54b852b/stderr
 [2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
 [32m[PASS]  [0mafc104393bac [36mtemporary files[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/afc104393bac/log
 [32m[PASS]  [0m1f85f39d5e9a [36muser output capture[0m
@@ -1194,7 +1194,7 @@ Try '--help' for options.
 [2m• [0mChecked output: stdout
 [2m• [0mChecked output files: results.txt, results.json
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/0658581e95c7/completion_status[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/0658581e95c7/stdout
+[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/0658581e95c7/stdout [.orig]
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/0658581e95c7/log
 [2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/0658581e95c7/file-results.txt
 [2m• [0mPath to captured results.json: _build/testo/status/testo_tests/0658581e95c7/file-results.json
@@ -1258,7 +1258,7 @@ Try '--help' for options.
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/a3e1a604f579/completion_status[0m
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/a3e1a604f579/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log
 [33m[MISS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/3b24997d50c8/completion_status[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
@@ -1287,22 +1287,22 @@ Try '--help' for options.
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d5b0041ea8f4/completion_status[0m
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/d5b0041ea8f4/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log
 [33m[MISS]  [0m99746f633129 [36mcheck words in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/99746f633129/completion_status[0m
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/99746f633129/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log
 [33m[MISS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/7e7e7c09bfff/completion_status[0m
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/7e7e7c09bfff/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log
 [33m[MISS]  [0m065cc54b852b [36malcotest error formatting[0m
 [2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/065cc54b852b/completion_status[0m
 [2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
 [33m[MISS]  [0mafc104393bac [36mtemporary files[0m
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/afc104393bac/completion_status[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/afc104393bac/log
@@ -1547,7 +1547,7 @@ Try '--help' for options.
 [0m[2m• [0mChecked output: stdout
 [2m• [0mChecked output files: results.txt, results.json
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/0658581e95c7/completion_status[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/0658581e95c7/stdout
+[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/0658581e95c7/stdout [.orig]
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/0658581e95c7/log
 [2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/0658581e95c7/file-results.txt
 [2m• [0mPath to captured results.json: _build/testo/status/testo_tests/0658581e95c7/file-results.json
@@ -1654,7 +1654,7 @@ Try '--help' for options.
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/a3e1a604f579/completion_status[0m
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/a3e1a604f579/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m                                       [2m│[0m
@@ -1710,7 +1710,7 @@ Try '--help' for options.
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d5b0041ea8f4/completion_status[0m
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/d5b0041ea8f4/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m99746f633129 [36mcheck words in stdout[0m                                   [2m│[0m
@@ -1718,7 +1718,7 @@ Try '--help' for options.
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/99746f633129/completion_status[0m
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/99746f633129/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m                          [2m│[0m
@@ -1726,7 +1726,7 @@ Try '--help' for options.
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/7e7e7c09bfff/completion_status[0m
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/7e7e7c09bfff/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m065cc54b852b [36malcotest error formatting[0m                               [2m│[0m
@@ -1734,7 +1734,7 @@ Try '--help' for options.
 [0m[2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/065cc54b852b/completion_status[0m
 [2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0mafc104393bac [36mtemporary files[0m                                         [2m│[0m
@@ -2104,7 +2104,7 @@ junk printed on stdout...
 [0m[2m• [0mChecked output: stdout
 [2m• [0mChecked output files: results.txt, results.json
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/0658581e95c7/completion_status[0m
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/0658581e95c7/stdout
+[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/0658581e95c7/stdout [.orig]
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/0658581e95c7/log
 [2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/0658581e95c7/file-results.txt
 [2m• [0mPath to captured results.json: _build/testo/status/testo_tests/0658581e95c7/file-results.json
@@ -2211,7 +2211,7 @@ junk printed on stdout...
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/a3e1a604f579/completion_status[0m
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/a3e1a604f579/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m                                       [2m│[0m
@@ -2267,7 +2267,7 @@ junk printed on stdout...
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d5b0041ea8f4/completion_status[0m
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/d5b0041ea8f4/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m99746f633129 [36mcheck words in stdout[0m                                   [2m│[0m
@@ -2275,7 +2275,7 @@ junk printed on stdout...
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/99746f633129/completion_status[0m
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/99746f633129/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m                          [2m│[0m
@@ -2283,7 +2283,7 @@ junk printed on stdout...
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/7e7e7c09bfff/completion_status[0m
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/7e7e7c09bfff/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m065cc54b852b [36malcotest error formatting[0m                               [2m│[0m
@@ -2291,7 +2291,7 @@ junk printed on stdout...
 [0m[2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/065cc54b852b/completion_status[0m
 [2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0mafc104393bac [36mtemporary files[0m                                         [2m│[0m
@@ -2732,7 +2732,7 @@ Try '--help' for options.
 [2m• [0mChecked output: stdout
 [2m• [0mChecked output files: results.txt, results.json
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/0658581e95c7/stdout
-[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/0658581e95c7/stdout
+[2m• [0mPath to captured stdout: _build/testo/status/testo_tests/0658581e95c7/stdout [.orig]
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/0658581e95c7/log
 [2m• [0mPath to expected results.txt: tests/snapshots/testo_tests/0658581e95c7/file-results.txt
 [2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/0658581e95c7/file-results.txt
@@ -2818,7 +2818,7 @@ Try '--help' for options.
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/a3e1a604f579/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/a3e1a604f579/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/a3e1a604f579/log
 [33m[RUN][0m   3b24997d50c8 [36mmask_pcre_pattern[0m
 [32m[PASS]  [0m3b24997d50c8 [36mmask_pcre_pattern[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/3b24997d50c8/log
@@ -2848,25 +2848,25 @@ Try '--help' for options.
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/d5b0041ea8f4/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/d5b0041ea8f4/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/d5b0041ea8f4/log
 [33m[RUN][0m   99746f633129 [36mcheck words in stdout[0m
 [32m[PASS]  [0m99746f633129 [36mcheck words in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/99746f633129/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/99746f633129/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/99746f633129/log
 [33m[RUN][0m   7e7e7c09bfff [36mcheck for substrings in stdout[0m
 [32m[PASS]  [0m7e7e7c09bfff [36mcheck for substrings in stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/testo_tests/7e7e7c09bfff/stdout
 [2m• [0mPath to captured stdout: _build/testo/status/testo_tests/7e7e7c09bfff/stdout [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/7e7e7c09bfff/log
 [33m[RUN][0m   065cc54b852b [36malcotest error formatting[0m
 [32m[PASS]  [0m065cc54b852b [36malcotest error formatting[0m
 [2m• [0mChecked output: stderr
 [2m• [0mPath to expected stderr: tests/snapshots/testo_tests/065cc54b852b/stderr
 [2m• [0mPath to captured stderr: _build/testo/status/testo_tests/065cc54b852b/stderr [.orig]
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log [.orig]
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/065cc54b852b/log
 [33m[RUN][0m   afc104393bac [36mtemporary files[0m
 [32m[PASS]  [0mafc104393bac [36mtemporary files[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/afc104393bac/log

--- a/tests/snapshots/testo_tests/0658581e95c7/stdout
+++ b/tests/snapshots/testo_tests/0658581e95c7/stdout
@@ -1,1 +1,1 @@
-this is a message on stdout
+[normalized] this is a message on stdout


### PR DESCRIPTION
Closes https://github.com/semgrep/testo/issues/151

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.