### PR TITLE
Rewrap test function for more clarity and better error handling

### DIFF
--- a/tests/Meta_test.ml
+++ b/tests/Meta_test.ml
@@ -134,7 +134,7 @@ let test_standard_flow () =
     test_status ~__LOC__ "--env A_b123=xxx";
     test_status ~__LOC__ "-e novalue" ~expected_exit_code:124;
     test_status ~__LOC__ "-e b@d_key=42" ~expected_exit_code:124;
-    test_status ~__LOC__ "-a -t testin" ~expected_exit_code:1;
+    test_status ~__LOC__ "-a -t testin" ~expected_exit_code:2;
     test_status ~__LOC__ "-a -t testing";
     test_status ~__LOC__ "--strict" ~expected_exit_code:1;
     (* Modify the output of the test named 'environment-sensitive'

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -225,6 +225,24 @@ Try '--help' for options.
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
  
 [33m[RUN][0m   0ac34585feff [36mauto show exception on xfail[0m
 [32m[XFAIL] [0m0ac34585feff [36mauto show exception on xfail[0m
@@ -261,6 +279,24 @@ Try '--help' for options.
 [2m• [0mException raised by the test:
  Failure("I am broken")
  Raised at <MASKED>, line 29, characters 17-33
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
  Called from <MASKED>
  Called from <MASKED>
  
@@ -542,6 +578,24 @@ Try '--help' for options.
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
  
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
@@ -676,6 +730,24 @@ Try '--help' for options.
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
  
 [32m[XFAIL] [0m0ac34585feff [36mauto show exception on xfail[0m
 [2m• [0mExpected to fail: raises Failure exception on purpose
@@ -706,6 +778,24 @@ Try '--help' for options.
 [2m• [0mException raised by the test:
  Failure("I am broken")
  Raised at <MASKED>, line 29, characters 17-33
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
  Called from <MASKED>
  Called from <MASKED>
  
@@ -942,6 +1032,24 @@ Try '--help' for options.
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
  
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
@@ -1012,7 +1120,7 @@ test: option '-e': Malformed KEY=VALUE pair: b@d_key=42
 Usage: test status [OPTION]…
 Try 'test status --help' or 'test --help' for more information.
 RUN ./test status -e foo=bar -a -t testin
-Error: Unknown or misspelled tag: testin
+Fatal configuration error: Unknown or misspelled tag: testin
 RUN ./test status -e foo=bar -a -t testing
 junk printed on stdout...
 ... when creating the test suite
@@ -2760,6 +2868,24 @@ Try '--help' for options.
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
  
 [33m[RUN][0m   0ac34585feff [36mauto show exception on xfail[0m
 [32m[XFAIL] [0m0ac34585feff [36mauto show exception on xfail[0m
@@ -2796,6 +2922,24 @@ Try '--help' for options.
 [2m• [0mException raised by the test:
  Failure("I am broken")
  Raised at <MASKED>, line 29, characters 17-33
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
  Called from <MASKED>
  Called from <MASKED>
  
@@ -3010,6 +3154,24 @@ Try '--help' for options.
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
  
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [31m[FAIL]  [0m54ddc3c7d064 [36mbroken[0m
@@ -3070,6 +3232,24 @@ junk printed on stdout...
  Raised at <MASKED>, line 29, characters 17-33
  Called from <MASKED>
  Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
  
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 2 folders no longer belong to the test suite and are being removed:
@@ -3097,6 +3277,24 @@ junk printed on stdout...
 [2m• [0mException raised by the test:
  Failure("I am broken")
  Raised at <MASKED>, line 29, characters 17-33
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
+ Called from <MASKED>
+ Called from <MASKED>
+ Re-raised at <MASKED>
  Called from <MASKED>
  Called from <MASKED>
  

--- a/util/lib/Error.ml
+++ b/util/lib/Error.ml
@@ -25,3 +25,10 @@ let () =
     | Internal_error { loc; msg } ->
         Some (sprintf "Internal error in the Testo library at %s: %s" loc msg)
     | _ -> None)
+
+module Exit_code = struct
+  let success = 0
+  let test_failure = 1
+  let configuration_error = 2
+  let internal_error = 3
+end

--- a/util/lib/Error.mli
+++ b/util/lib/Error.mli
@@ -39,3 +39,16 @@ val assert_false : __LOC__:string -> unit -> 'a
 
 (* A replacement for the standard 'invalid_arg' function and exception. *)
 val invalid_arg : __LOC__:string -> string -> 'a
+
+module Exit_code : sig
+  val success : int
+
+  (* one or more tests failed *)
+  val test_failure : int
+
+  (* misconfiguration or other misuse fixable by the user *)
+  val configuration_error : int
+
+  (* other errors: bugs, broken files reserved for Testo's use *)
+  val internal_error : int
+end

--- a/util/lib/Msg_from_worker.ml
+++ b/util/lib/Msg_from_worker.ml
@@ -36,6 +36,8 @@ let of_string str =
       | "ERROR" -> Error payload
       | _ -> Junk str)
 
+(* TODO: properly encode newlines so that we can decode long messages such
+   as stack traces into something more readable *)
 let replace_newlines str =
   String.map
     (function

--- a/util/lib/Multiprocess.ml
+++ b/util/lib/Multiprocess.ml
@@ -410,5 +410,6 @@ module Server = struct
 
   let fatal_error str =
     write (Error str);
-    exit 1
+    (* Internal error: see exit codes in Error.ml *)
+    exit 3
 end


### PR DESCRIPTION
This is a preliminary for troubleshooting an internal error we're having. It catches the exception raised by the user function as early as possible without re-raising it, allowing any other exceptions to indicate internal errors.

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.