### PR TITLE
Catch errors in server loop and exit more gracefully

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ x.x.x (xxxx-xx-xx)
   of unchecked test output (logs) shown inline when reporting the
   status of a test. The default limit is 1MB
   ([#144](https://github.com/semgrep/testo/issues/144)).
+* Improve internal error handling ([#153](https://github.com/semgrep/testo/pull/153), [#154](https://github.com/semgrep/testo/pull/154)).
 
 0.2.0 (2025-09-11)
 ------------------


### PR DESCRIPTION
Catch and report exceptions due to internal errors arising when printing test statuses in the scheduler's loop and other operations that aren't supposed to fail. This tries to close the workers cleanly, saving them from a confusing death by broken pipe.

Test plan: add a `if Random.int 5 = 0 then failwith "debugging" |> ignore;`​ at the beginning of the `print_status`​ function to simulate a real error. Then run `./test`​. Change the argument to `Random.int`​ to trigger the error in other contexts.

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.