### PR TITLE
Check for both files before attempting a diff

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ x.x.x (xxxx-xx-xx)
   status of a test. The default limit is 1MB
   ([#144](https://github.com/semgrep/testo/issues/144)).
 * Improve internal error handling ([#153](https://github.com/semgrep/testo/pull/153), [#154](https://github.com/semgrep/testo/pull/154)).
+* Fix internal error that occurs when diffing checked output
+  files that don't exist ([#155](https://github.com/semgrep/testo/pull/155)).
 
 0.2.0 (2025-09-11)
 ------------------

--- a/core/Store.mli
+++ b/core/Store.mli
@@ -118,7 +118,7 @@ type changed = Changed | Unchanged
 
    Returns an error message if the test status is not PASS or XFAIL.
 *)
-val approve_new_output : Types.test -> (changed, string) Result.t
+val approve_new_output : Types.test -> (changed, Testo_util.Error.msg) Result.t
 
 (*
    If a test is configured to normalize its output, this returns the

--- a/tests/Test.ml
+++ b/tests/Test.ml
@@ -455,6 +455,12 @@ let tests env =
            Testo.stash_output_file output_file "results.txt"
          )
       );
+    t "fail to capture one file"
+      ~expected_outcome:(Should_fail "must raise exception")
+      ~checked_output_files:[
+        Testo.checked_output_file "results.txt"
+      ]
+      (fun () -> failwith "I am failing on purpose");
     t "capture multiple files and stdout"
       ~normalize:[(fun s -> "[normalized] " ^ s)]
       ~checked_output:(Testo.stdout ())

--- a/tests/snapshots/testo_meta_tests/09a1af4a20b0/stdout
+++ b/tests/snapshots/testo_meta_tests/09a1af4a20b0/stdout
@@ -32,7 +32,7 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-3/81 selected tests:
+3/82 selected tests:
   3 successful (3 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m

--- a/tests/snapshots/testo_meta_tests/b44050392a05/stdout
+++ b/tests/snapshots/testo_meta_tests/b44050392a05/stdout
@@ -29,7 +29,7 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-3/81 selected tests:
+3/82 selected tests:
   3 successful (3 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -28,6 +28,7 @@ junk printed on stdout...
 [33m[MISS]  [0medebe706faa8 [36mauto-approve[0m > [36mcapture stdxxx in custom location[0m
 [33m[MISS]  [0md7f47c9a03b6 [36mauto-approve[0m > [36mcapture stdout and stderr in custom location[0m
 [33m[MISS]  [0md0fb18eaf104 [36mcapture one file[0m
+[33m[MISS]  [0m894b5f5931fd [36mfail to capture one file[0m
 [33m[MISS]  [0m0658581e95c7 [36mcapture multiple files and stdout[0m
 [33m[MISS]  [0m57fbfca04c25 [36minline logs[0m
 [33m[MISS]  [0m9c3540949276 [36mauto inline logs[0m
@@ -192,6 +193,16 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/d0fb18eaf104/log
 [2m• [0mPath to expected results.txt: tests/snapshots/testo_tests/d0fb18eaf104/file-results.txt
 [2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/d0fb18eaf104/file-results.txt
+[33m[RUN][0m   894b5f5931fd [36mfail to capture one file[0m
+[32m[XFAIL*] [0m894b5f5931fd [36mfail to capture one file[0m
+[2m• [0mExpected to fail: must raise exception
+[2m• [0mChecked output file: results.txt
+[2m• [0m[31mMissing captured output file: _build/testo/status/testo_tests/894b5f5931fd/file-results.txt[0m
+[2m• [0m[2mIf you ran the test already, you may have forgotten to call 'Testo.stash_output_file' in the test function.[0m
+[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/894b5f5931fd/file-results.txt[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/894b5f5931fd/log
+[2m• [0mPath to expected results.txt: tests/snapshots/testo_tests/894b5f5931fd/file-results.txt
+[2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/894b5f5931fd/file-results.txt
 [33m[RUN][0m   0658581e95c7 [36mcapture multiple files and stdout[0m
 [32m[PASS]  [0m0658581e95c7 [36mcapture multiple files and stdout[0m
 [2m• [0mChecked output: stdout
@@ -620,9 +631,9 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-81/81 selected tests:
+82/82 selected tests:
   1 skipped
-  79 successful (73 pass, 6 xfail)
+  80 successful (73 pass, 7 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -702,6 +713,15 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/d0fb18eaf104/log
 [2m• [0mPath to expected results.txt: tests/snapshots/testo_tests/d0fb18eaf104/file-results.txt
 [2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/d0fb18eaf104/file-results.txt
+[32m[XFAIL*] [0m894b5f5931fd [36mfail to capture one file[0m
+[2m• [0mExpected to fail: must raise exception
+[2m• [0mChecked output file: results.txt
+[2m• [0m[31mMissing captured output file: _build/testo/status/testo_tests/894b5f5931fd/file-results.txt[0m
+[2m• [0m[2mIf you ran the test already, you may have forgotten to call 'Testo.stash_output_file' in the test function.[0m
+[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/894b5f5931fd/file-results.txt[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/894b5f5931fd/log
+[2m• [0mPath to expected results.txt: tests/snapshots/testo_tests/894b5f5931fd/file-results.txt
+[2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/894b5f5931fd/file-results.txt
 [32m[PASS]  [0m0658581e95c7 [36mcapture multiple files and stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mChecked output files: results.txt, results.json
@@ -1064,9 +1084,9 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-81/81 selected tests:
+82/82 selected tests:
   1 skipped
-  79 successful (73 pass, 6 xfail)
+  80 successful (73 pass, 7 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
@@ -1183,7 +1203,7 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-1/81 selected tests:
+1/82 selected tests:
   0 successful (0 pass, 0 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [31mfailure[0m
@@ -1213,7 +1233,7 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-1/81 selected tests:
+1/82 selected tests:
   1 successful (1 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
 overall status: [32msuccess[0m
@@ -1298,6 +1318,13 @@ Try '--help' for options.
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/d0fb18eaf104/completion_status[0m
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/d0fb18eaf104/log
 [2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/d0fb18eaf104/file-results.txt
+[33m[MISS]  [0m894b5f5931fd [36mfail to capture one file[0m
+[2m• [0mExpected to fail: must raise exception
+[2m• [0mChecked output file: results.txt
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/894b5f5931fd/completion_status[0m
+[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/894b5f5931fd/file-results.txt[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/894b5f5931fd/log
+[2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/894b5f5931fd/file-results.txt
 [33m[MISS]  [0m0658581e95c7 [36mcapture multiple files and stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mChecked output files: results.txt, results.json
@@ -1650,6 +1677,16 @@ Try '--help' for options.
 [2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/d0fb18eaf104/file-results.txt
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m894b5f5931fd [36mfail to capture one file[0m                                [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mExpected to fail: must raise exception
+[2m• [0mChecked output file: results.txt
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/894b5f5931fd/completion_status[0m
+[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/894b5f5931fd/file-results.txt[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/894b5f5931fd/log
+[2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/894b5f5931fd/file-results.txt
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m0658581e95c7 [36mcapture multiple files and stdout[0m                       [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
@@ -2089,11 +2126,11 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-81/81 selected tests:
+82/82 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-80 new tests
+81 new tests
 overall status: [31mfailure[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
 <handling result before exiting>
@@ -2207,6 +2244,16 @@ junk printed on stdout...
 [2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/d0fb18eaf104/file-results.txt
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
+[0m[2m│[0m [33m[MISS]  [0m894b5f5931fd [36mfail to capture one file[0m                                [2m│[0m
+[2m└──────────────────────────────────────────────────────────────────────────────┘
+[0m[2m• [0mExpected to fail: must raise exception
+[2m• [0mChecked output file: results.txt
+[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/894b5f5931fd/completion_status[0m
+[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/894b5f5931fd/file-results.txt[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/894b5f5931fd/log
+[2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/894b5f5931fd/file-results.txt
+[2m────────────────────────────────────────────────────────────────────────────────[0m
+[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m0658581e95c7 [36mcapture multiple files and stdout[0m                       [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
@@ -2646,11 +2693,11 @@ junk printed on stdout...
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-81/81 selected tests:
+82/82 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-80 new tests
+81 new tests
 overall status: [31mfailure[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
 <handling result before exiting>
@@ -2672,6 +2719,7 @@ junk printed on stdout...
 [33m[MISS]  [0medebe706faa8 [36mauto-approve[0m > [36mcapture stdxxx in custom location[0m
 [33m[MISS]  [0md7f47c9a03b6 [36mauto-approve[0m > [36mcapture stdout and stderr in custom location[0m
 [33m[MISS]  [0md0fb18eaf104 [36mcapture one file[0m
+[33m[MISS]  [0m894b5f5931fd [36mfail to capture one file[0m
 [33m[MISS]  [0m0658581e95c7 [36mcapture multiple files and stdout[0m
 [33m[MISS]  [0m57fbfca04c25 [36minline logs[0m
 [33m[MISS]  [0m9c3540949276 [36mauto inline logs[0m
@@ -2835,6 +2883,16 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/d0fb18eaf104/log
 [2m• [0mPath to expected results.txt: tests/snapshots/testo_tests/d0fb18eaf104/file-results.txt
 [2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/d0fb18eaf104/file-results.txt
+[33m[RUN][0m   894b5f5931fd [36mfail to capture one file[0m
+[32m[XFAIL*] [0m894b5f5931fd [36mfail to capture one file[0m
+[2m• [0mExpected to fail: must raise exception
+[2m• [0mChecked output file: results.txt
+[2m• [0m[31mMissing captured output file: _build/testo/status/testo_tests/894b5f5931fd/file-results.txt[0m
+[2m• [0m[2mIf you ran the test already, you may have forgotten to call 'Testo.stash_output_file' in the test function.[0m
+[2m• [0m[31mMissing file containing the expected output: tests/snapshots/testo_tests/894b5f5931fd/file-results.txt[0m
+[2m• [0mPath to captured log: _build/testo/status/testo_tests/894b5f5931fd/log
+[2m• [0mPath to expected results.txt: tests/snapshots/testo_tests/894b5f5931fd/file-results.txt
+[2m• [0mPath to captured results.txt: _build/testo/status/testo_tests/894b5f5931fd/file-results.txt
 [33m[RUN][0m   0658581e95c7 [36mcapture multiple files and stdout[0m
 [32m[PASS]  [0m0658581e95c7 [36mcapture multiple files and stdout[0m
 [2m• [0mChecked output: stdout
@@ -3178,9 +3236,9 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-81/81 selected tests:
+82/82 selected tests:
   1 skipped
-  79 successful (73 pass, 6 xfail)
+  80 successful (73 pass, 7 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [32msuccess[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
@@ -3255,9 +3313,9 @@ junk printed on stdout...
 2 folders no longer belong to the test suite and are being removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-81/81 selected tests:
+82/82 selected tests:
   1 skipped
-  79 successful (73 pass, 6 xfail)
+  80 successful (73 pass, 7 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [32msuccess[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
@@ -3299,9 +3357,9 @@ junk printed on stdout...
  Called from <MASKED>
  
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-81/81 selected tests:
+82/82 selected tests:
   1 skipped
-  79 successful (73 pass, 6 xfail)
+  80 successful (73 pass, 7 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [32msuccess[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m

--- a/tests/snapshots/testo_tests/894b5f5931fd/name
+++ b/tests/snapshots/testo_tests/894b5f5931fd/name
@@ -1,0 +1,1 @@
+fail to capture one file

--- a/util/lib/Error.ml
+++ b/util/lib/Error.ml
@@ -4,6 +4,10 @@
 
 open Printf
 
+type msg =
+  | Error of string
+  | Warning of string
+
 exception Test_failure of string
 exception User_error of string
 exception Internal_error of { loc : string; msg : string }

--- a/util/lib/Error.mli
+++ b/util/lib/Error.mli
@@ -2,6 +2,11 @@
    Error management and exception printing
 *)
 
+(* A type for carrying informational messages *)
+type msg =
+  | Error of string
+  | Warning of string
+
 (*
    An exception that can be used in a test function to signal a test failure.
    The advantage over using the built-in 'Failure' exception is that


### PR DESCRIPTION
Don't fail when printing a test status if the test didn't stash an output file like it should.

Test plan: this is dependent on an internal malfunction that is hard to reproduce and was causing a crash of the test suite. To reproduce, insert a `Sys.remove !!path_to_output;`​ at the beginning of the `show_diff`​ function. `show_diff`​ should no longer raise an exception (but of course will likely cause a failure later).

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.