### PR TITLE
Open files in text mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,19 @@ x.x.x (xxxx-xx-xx)
 * Report and highlight differences in Unix vs. Windows line endings as
   well as missing trailing newlines
   ([#163](https://github.com/semgrep/testo/pull/163).
+* Testo's snapshot files are now open in text mode for Windows-Unix
+  compatibility. When reading files on Windows, CRLFs are converted to
+  LFs. When writing, LFs are converted to CRLFs. Git or equivalent
+  must be set up to convert line endings appropriately when moving
+  files across platforms
+  ([#165](https://github.com/semgrep/testo/pull/165)).
+* A series of functions for reading and writing files has been deprecated
+  and renamed to hint that we're reading or writing in text mode on
+  Windows. These functions are `write_file`, `read_file`, `map_file`,
+  `copy_file`, and `with_temp_file`. The new names are
+  `write_text_file`, `read_text_file`, etc.
+  ([#165](https://github.com/semgrep/testo/pull/165)).
+* Testo's own test suite now passes successfully on Windows.
 
 0.2.0 (2025-09-11)
 ------------------

--- a/core/Cmd.ml
+++ b/core/Cmd.ml
@@ -106,7 +106,12 @@ let run_with_conf ((get_tests, handle_subcommand_result) : _ test_spec)
   *)
   match cmd_conf with
   | Run_tests conf ->
-      if conf.is_worker then ignore_broken_pipe ();
+      if conf.is_worker then (
+        ignore_broken_pipe ();
+        (* Make sure to communicate over the pipe in binary mode to avoid
+           CRLF<->LF conversions *)
+        set_binary_mode_in stdin true;
+        set_binary_mode_out stdout true);
       Debug.debug := conf.debug;
       let tests = get_tests conf.env in
       Run.cmd_run

--- a/core/Temp_file.ml
+++ b/core/Temp_file.ml
@@ -6,14 +6,14 @@ open Testo_util
 open Fpath_.Operators
 module P = Promise
 
-let with_temp_file ?contents ?(persist = false) ?(prefix = "testo-")
+let with_temp_text_file ?contents ?(persist = false) ?(prefix = "testo-")
     ?(suffix = "") ?temp_dir func =
   let path = Filename_.temp_file ?temp_dir prefix suffix in
   P.protect
     (fun () ->
       (match contents with
       | None -> ()
-      | Some data -> Helpers.write_file path data);
+      | Some data -> Helpers.write_text_file path data);
       func path)
     ~finally:(fun () ->
       if not persist then Sys.remove !!path;

--- a/core/Temp_file.mli
+++ b/core/Temp_file.mli
@@ -1,5 +1,5 @@
 (* Work with a temporary file, ensuring its eventual deletion. *)
-val with_temp_file :
+val with_temp_text_file :
   ?contents:string ->
   ?persist:bool ->
   ?prefix:string ->

--- a/core/Testo.ml
+++ b/core/Testo.ml
@@ -254,12 +254,19 @@ let fail = Testo_util.Error.fail_test
 (* Files and output manipulation *)
 (**************************************************************************)
 
-let write_file = Helpers.write_file
-let read_file = Helpers.read_file
-let map_file = Helpers.map_file
-let copy_file = Helpers.copy_file
-let with_temp_file = Temp_file.with_temp_file
+let write_text_file = Helpers.write_text_file
+let read_text_file = Helpers.read_text_file
+let map_text_file = Helpers.map_text_file
+let copy_text_file = Helpers.copy_text_file
+let with_temp_text_file = Temp_file.with_temp_text_file
 let with_capture = Store.with_capture
+
+(* Deprecated function names *)
+let write_file = write_text_file
+let read_file = read_text_file
+let map_file = map_text_file
+let copy_file = copy_text_file
+let with_temp_file = with_temp_text_file
 
 let with_chdir path func =
   let orig_cwd = Unix.getcwd () in

--- a/core/Testo.mli
+++ b/core/Testo.mli
@@ -377,26 +377,47 @@ val fail : string -> unit
 (** {2 Temporary files and output redirection} *)
 
 val write_file : Fpath.t -> string -> unit
+[@@deprecated "Use write_text_file instead."]
+
+val read_file : Fpath.t -> string [@@deprecated "Use read_text_file instead."]
+
+val map_file : (string -> string) -> Fpath.t -> Fpath.t -> unit
+[@@deprecated "Use map_text_file instead."]
+
+val copy_file : Fpath.t -> Fpath.t -> unit
+[@@deprecated "Use copy_text_file instead."]
+
+val with_temp_file :
+  ?contents:string ->
+  ?persist:bool ->
+  ?prefix:string ->
+  ?suffix:string ->
+  ?temp_dir:Fpath.t ->
+  (Fpath.t -> 'a Promise.t) ->
+  'a Promise.t
+[@@deprecated "Use with_temp_text_file instead."]
+
+val write_text_file : Fpath.t -> string -> unit
 (** Write data to a regular file. Create the file if it doesn't exist. Erase any
     existing data.
 
     Usage: [write_file path data] *)
 
-val read_file : Fpath.t -> string
+val read_text_file : Fpath.t -> string
 (** Read the contents of a regular file or symbolic link to a regular file. *)
 
-val map_file : (string -> string) -> Fpath.t -> Fpath.t -> unit
+val map_text_file : (string -> string) -> Fpath.t -> Fpath.t -> unit
 (** [map_file func src dst] reads the contents of file (regular or symlink)
     [src], applies [func] to its contents, and writes the result into file
     [dst]. If file [dst] already exists, it is truncated and overwritten.
     Otherwise, a regular file is created. If [src] and [dst] represent the same
     file, [src] will be overwritten with the new contents. *)
 
-val copy_file : Fpath.t -> Fpath.t -> unit
+val copy_text_file : Fpath.t -> Fpath.t -> unit
 (** Copy a file. [copy_file src dst] is a shortcut for
     [map_file (fun data -> data) src dst]. *)
 
-val with_temp_file :
+val with_temp_text_file :
   ?contents:string ->
   ?persist:bool ->
   ?prefix:string ->

--- a/tests/snapshots/testo_meta_tests/09a1af4a20b0/stdout
+++ b/tests/snapshots/testo_meta_tests/09a1af4a20b0/stdout
@@ -1,4 +1,4 @@
-RUN ./test run -e foo=bar -j 1 -s 'inline logs' --max-inline-log-bytes 5
+RUN ./test run -e foo=bar -j 1 -s 'inline logs' --max-inline-log-bytes 5 -t 'not unix_only'
 junk printed on stdout...
 ... when creating the test suite
 Legend:

--- a/tests/snapshots/testo_meta_tests/14c5e5fd13eb/stdxxx
+++ b/tests/snapshots/testo_meta_tests/14c5e5fd13eb/stdxxx
@@ -1,7 +1,7 @@
 #####################################################################
 # Approve the incorrect output of an XFAIL test
 #####################################################################
-RUN ./test approve -e foo=bar -s '05dd9a9f220b'
+RUN ./test approve -t 'not unix_only' -e foo=bar -s '05dd9a9f220b'
 junk printed on stdout...
 ... when creating the test suite
 Expected output changed for 1 test.
@@ -9,7 +9,7 @@ Expected output changed for 1 test.
 #####################################################################
 # Now expect XPASS status
 #####################################################################
-RUN ./test status -e foo=bar -s '05dd9a9f220b'
+RUN ./test status -t 'not unix_only' -e foo=bar -s '05dd9a9f220b'
 junk printed on stdout...
 ... when creating the test suite
 [31m[XPASS] [0m05dd9a9f220b [36mxfail due to invalid output[0m

--- a/tests/snapshots/testo_meta_tests/b44050392a05/stdout
+++ b/tests/snapshots/testo_meta_tests/b44050392a05/stdout
@@ -1,4 +1,4 @@
-RUN ./test run -e foo=bar -j 1 -s 'inline logs' --max-inline-log-bytes unlimited
+RUN ./test run -e foo=bar -j 1 -s 'inline logs' --max-inline-log-bytes unlimited -t 'not unix_only'
 junk printed on stdout...
 ... when creating the test suite
 Legend:

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -10,7 +10,7 @@ RUN rm -rf tests/snapshots/testo_tests/f66d12950c64
 RUN rm -rf tests/snapshots/testo_tests/caadabfd495c
 RUN mkdir -p tests/custom-snapshots
 RUN rm -f tests/custom-snapshots/*
-RUN ./test status -e foo=bar 
+RUN ./test status -t 'not unix_only' -e foo=bar 
 junk printed on stdout...
 ... when creating the test suite
 [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m
@@ -69,10 +69,6 @@ junk printed on stdout...
 [33m[MISS]  [0m1cf5a6371f59 [36mdiff[0m > [36mtrailing-context[0m
 [33m[MISS]  [0m8ae0ad03ce59 [36mdiff[0m > [36mjoined-context[0m
 [33m[MISS]  [0m360c4b690be4 [36mdiff[0m > [36mgap-in-context[0m
-[33m[MISS]  [0me9a14b7e5dd9 [36mdiff[0m > [36mlf-crlf-only[0m
-[33m[MISS]  [0m8f4b9e56ac4d [36mdiff[0m > [36mcrlf-lf-only[0m
-[33m[MISS]  [0m8339c60608b4 [36mdiff[0m > [36mlf-crlf[0m
-[33m[MISS]  [0mee1aad685657 [36mdiff[0m > [36mcrlf-lf[0m
 [33m[MISS]  [0mb23196a133ca [36mdiff[0m > [36mmissing-eol-only[0m
 [33m[MISS]  [0mca552d6359ef [36mdiff[0m > [36mmissing-eol[0m
 [33m[MISS]  [0m08e4221951ee [36mcurrent test[0m
@@ -112,7 +108,7 @@ junk printed on stdout...
 [33m[MISS]  [0mbf55db9dc3f0 [36mshared context split output 1[0m
 [33m[MISS]  [0mcb28cacab289 [36mshared context split output 2[0m
 <handling result before exiting>
-RUN ./test run -e foo=bar -j 1 
+RUN ./test run -e foo=bar -j 1  -t 'not unix_only'
 junk printed on stdout...
 ... when creating the test suite
 Legend:
@@ -466,30 +462,6 @@ Try '--help' for options.
 [2m• [0mPath to expected gap-in-context.diff: tests/diff-data/gap-in-context.diff
 [2m• [0mPath to captured gap-in-context.diff: _build/testo/status/testo_tests/360c4b690be4/stdout
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/360c4b690be4/log
-[33m[RUN][0m   e9a14b7e5dd9 [36mdiff[0m > [36mlf-crlf-only[0m
-[32m[PASS]  [0me9a14b7e5dd9 [36mdiff[0m > [36mlf-crlf-only[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected lf-crlf-only.diff: tests/diff-data/lf-crlf-only.diff
-[2m• [0mPath to captured lf-crlf-only.diff: _build/testo/status/testo_tests/e9a14b7e5dd9/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/e9a14b7e5dd9/log
-[33m[RUN][0m   8f4b9e56ac4d [36mdiff[0m > [36mcrlf-lf-only[0m
-[32m[PASS]  [0m8f4b9e56ac4d [36mdiff[0m > [36mcrlf-lf-only[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected crlf-lf-only.diff: tests/diff-data/crlf-lf-only.diff
-[2m• [0mPath to captured crlf-lf-only.diff: _build/testo/status/testo_tests/8f4b9e56ac4d/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8f4b9e56ac4d/log
-[33m[RUN][0m   8339c60608b4 [36mdiff[0m > [36mlf-crlf[0m
-[32m[PASS]  [0m8339c60608b4 [36mdiff[0m > [36mlf-crlf[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected lf-crlf.diff: tests/diff-data/lf-crlf.diff
-[2m• [0mPath to captured lf-crlf.diff: _build/testo/status/testo_tests/8339c60608b4/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8339c60608b4/log
-[33m[RUN][0m   ee1aad685657 [36mdiff[0m > [36mcrlf-lf[0m
-[32m[PASS]  [0mee1aad685657 [36mdiff[0m > [36mcrlf-lf[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected crlf-lf.diff: tests/diff-data/crlf-lf.diff
-[2m• [0mPath to captured crlf-lf.diff: _build/testo/status/testo_tests/ee1aad685657/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/ee1aad685657/log
 [33m[RUN][0m   b23196a133ca [36mdiff[0m > [36mmissing-eol-only[0m
 [32m[PASS]  [0mb23196a133ca [36mdiff[0m > [36mmissing-eol-only[0m
 [2m• [0mChecked output: stdout
@@ -721,15 +693,15 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-99/99 selected tests:
+95/99 selected tests:
   1 skipped
-  97 successful (90 pass, 7 xfail)
+  93 successful (86 pass, 7 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
 <handling result before exiting>
-RUN ./test status -e foo=bar --all --long
+RUN ./test status -t 'not unix_only' -e foo=bar --all --long
 junk printed on stdout...
 ... when creating the test suite
 Legend:
@@ -1010,26 +982,6 @@ Try '--help' for options.
 [2m• [0mPath to expected gap-in-context.diff: tests/diff-data/gap-in-context.diff
 [2m• [0mPath to captured gap-in-context.diff: _build/testo/status/testo_tests/360c4b690be4/stdout
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/360c4b690be4/log
-[32m[PASS]  [0me9a14b7e5dd9 [36mdiff[0m > [36mlf-crlf-only[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected lf-crlf-only.diff: tests/diff-data/lf-crlf-only.diff
-[2m• [0mPath to captured lf-crlf-only.diff: _build/testo/status/testo_tests/e9a14b7e5dd9/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/e9a14b7e5dd9/log
-[32m[PASS]  [0m8f4b9e56ac4d [36mdiff[0m > [36mcrlf-lf-only[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected crlf-lf-only.diff: tests/diff-data/crlf-lf-only.diff
-[2m• [0mPath to captured crlf-lf-only.diff: _build/testo/status/testo_tests/8f4b9e56ac4d/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8f4b9e56ac4d/log
-[32m[PASS]  [0m8339c60608b4 [36mdiff[0m > [36mlf-crlf[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected lf-crlf.diff: tests/diff-data/lf-crlf.diff
-[2m• [0mPath to captured lf-crlf.diff: _build/testo/status/testo_tests/8339c60608b4/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8339c60608b4/log
-[32m[PASS]  [0mee1aad685657 [36mdiff[0m > [36mcrlf-lf[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected crlf-lf.diff: tests/diff-data/crlf-lf.diff
-[2m• [0mPath to captured crlf-lf.diff: _build/testo/status/testo_tests/ee1aad685657/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/ee1aad685657/log
 [32m[PASS]  [0mb23196a133ca [36mdiff[0m > [36mmissing-eol-only[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected missing-eol-only.diff: tests/diff-data/missing-eol-only.diff
@@ -1230,15 +1182,15 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-99/99 selected tests:
+95/99 selected tests:
   1 skipped
-  97 successful (90 pass, 7 xfail)
+  93 successful (86 pass, 7 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 9 tests whose output needs first-time approval
 overall status: [31mfailure[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
 <handling result before exiting>
-RUN ./test status -e foo=bar 
+RUN ./test status -t 'not unix_only' -e foo=bar 
 junk printed on stdout...
 ... when creating the test suite
 [33m[PASS*] [0m9c96a5aa8b4b ([1mmeta[0m) [36mauto-approve[0m > [36mcapture stdout[0m
@@ -1252,55 +1204,55 @@ junk printed on stdout...
 [31m[FAIL]  [0m54ddc3c7d064 ([1mmeta[0m) [36mbroken[0m
 [33m[PASS*] [0mf66d12950c64 [36mauto-approve[0m > [36minternal files[0m > [36mcreate name file[0m
 <handling result before exiting>
-RUN ./test approve -e foo=bar -s auto-approve
+RUN ./test approve -t 'not unix_only' -e foo=bar -s auto-approve
 junk printed on stdout...
 ... when creating the test suite
 Expected output changed for 9 tests.
 <handling result before exiting>
-RUN ./test approve -e foo=bar -s environment-sensitive
+RUN ./test approve -t 'not unix_only' -e foo=bar -s environment-sensitive
 junk printed on stdout...
 ... when creating the test suite
 Expected output changed for 0 test.
 <handling result before exiting>
-RUN ./test status -e foo=bar 
+RUN ./test status -t 'not unix_only' -e foo=bar 
 junk printed on stdout...
 ... when creating the test suite
 [31m[FAIL]  [0m54ddc3c7d064 ([1mmeta[0m) [36mbroken[0m
 <handling result before exiting>
-RUN ./test status -e foo=bar --expert
+RUN ./test status -t 'not unix_only' -e foo=bar --expert
 junk printed on stdout...
 ... when creating the test suite
 [31m[FAIL]  [0m54ddc3c7d064 ([1mmeta[0m) [36mbroken[0m
 <handling result before exiting>
-RUN ./test status -e foo=bar --env A_b123=xxx
+RUN ./test status -t 'not unix_only' -e foo=bar --env A_b123=xxx
 junk printed on stdout...
 ... when creating the test suite
 [31m[FAIL]  [0m54ddc3c7d064 ([1mmeta[0m) [36mbroken[0m
 <handling result before exiting>
-RUN ./test status -e foo=bar -e novalue
+RUN ./test status -t 'not unix_only' -e foo=bar -e novalue
 test.exe: option '-e': Malformed KEY=VALUE pair: novalue
 Usage: test.exe status [OPTION]…
 Try 'test.exe status --help' or 'test.exe --help' for more information.
-RUN ./test status -e foo=bar -e b@d_key=42
+RUN ./test status -t 'not unix_only' -e foo=bar -e b@d_key=42
 test.exe: option '-e': Malformed KEY=VALUE pair: b@d_key=42
 Usage: test.exe status [OPTION]…
 Try 'test.exe status --help' or 'test.exe --help' for more information.
-RUN ./test status -e foo=bar -a -t testin
+RUN ./test status -t 'testin' -e foo=bar -a
 test.exe: option '-t': Syntax error in tag query 'testin': Failure("Not a
           valid tag for this test suite: testin")
 Usage: test.exe status [OPTION]…
 Try 'test.exe status --help' or 'test.exe --help' for more information.
-RUN ./test status -e foo=bar -a -t testing
+RUN ./test status -t 'testing' -e foo=bar -a
 junk printed on stdout...
 ... when creating the test suite
 [32m[PASS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
 <handling result before exiting>
-RUN ./test status -e foo=bar --strict
+RUN ./test status -t 'not unix_only' -e foo=bar --strict
 junk printed on stdout...
 ... when creating the test suite
 [31m[FAIL]  [0m54ddc3c7d064 ([1mmeta[0m) [36mbroken[0m
 <handling result before exiting>
-RUN ./test run -e foo=bar -j 1 -s environment-sensitive
+RUN ./test run -e foo=bar -j 1 -s environment-sensitive -t 'not unix_only'
 junk printed on stdout...
 ... when creating the test suite
 Legend:
@@ -1355,7 +1307,7 @@ Try '--help' for options.
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [31mfailure[0m
 <handling result before exiting>
-RUN ./test run -e foo=bar -j 1 -s environment-sensitive
+RUN ./test run -e foo=bar -j 1 -s environment-sensitive -t 'not unix_only'
 junk printed on stdout...
 ... when creating the test suite
 Legend:
@@ -1389,7 +1341,7 @@ overall status: [32msuccess[0m
 # Delete statuses but not snapshots
 #####################################################################
 RUN rm -rf _build/testo/status/testo_tests
-RUN ./test status -e foo=bar -v
+RUN ./test status -t 'not unix_only' -e foo=bar -v
 junk printed on stdout...
 ... when creating the test suite
 Legend:
@@ -1639,26 +1591,6 @@ Try '--help' for options.
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/360c4b690be4/completion_status[0m
 [2m• [0mPath to captured gap-in-context.diff: _build/testo/status/testo_tests/360c4b690be4/stdout
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/360c4b690be4/log
-[33m[MISS]  [0me9a14b7e5dd9 [36mdiff[0m > [36mlf-crlf-only[0m
-[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e9a14b7e5dd9/completion_status[0m
-[2m• [0mPath to captured lf-crlf-only.diff: _build/testo/status/testo_tests/e9a14b7e5dd9/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/e9a14b7e5dd9/log
-[33m[MISS]  [0m8f4b9e56ac4d [36mdiff[0m > [36mcrlf-lf-only[0m
-[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8f4b9e56ac4d/completion_status[0m
-[2m• [0mPath to captured crlf-lf-only.diff: _build/testo/status/testo_tests/8f4b9e56ac4d/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8f4b9e56ac4d/log
-[33m[MISS]  [0m8339c60608b4 [36mdiff[0m > [36mlf-crlf[0m
-[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8339c60608b4/completion_status[0m
-[2m• [0mPath to captured lf-crlf.diff: _build/testo/status/testo_tests/8339c60608b4/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8339c60608b4/log
-[33m[MISS]  [0mee1aad685657 [36mdiff[0m > [36mcrlf-lf[0m
-[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/ee1aad685657/completion_status[0m
-[2m• [0mPath to captured crlf-lf.diff: _build/testo/status/testo_tests/ee1aad685657/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/ee1aad685657/log
 [33m[MISS]  [0mb23196a133ca [36mdiff[0m > [36mmissing-eol-only[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/b23196a133ca/completion_status[0m
@@ -2186,38 +2118,6 @@ Try '--help' for options.
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/360c4b690be4/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0me9a14b7e5dd9 [36mdiff[0m > [36mlf-crlf-only[0m                                     [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e9a14b7e5dd9/completion_status[0m
-[2m• [0mPath to captured lf-crlf-only.diff: _build/testo/status/testo_tests/e9a14b7e5dd9/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/e9a14b7e5dd9/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m8f4b9e56ac4d [36mdiff[0m > [36mcrlf-lf-only[0m                                     [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8f4b9e56ac4d/completion_status[0m
-[2m• [0mPath to captured crlf-lf-only.diff: _build/testo/status/testo_tests/8f4b9e56ac4d/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8f4b9e56ac4d/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m8339c60608b4 [36mdiff[0m > [36mlf-crlf[0m                                          [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8339c60608b4/completion_status[0m
-[2m• [0mPath to captured lf-crlf.diff: _build/testo/status/testo_tests/8339c60608b4/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8339c60608b4/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0mee1aad685657 [36mdiff[0m > [36mcrlf-lf[0m                                          [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/ee1aad685657/completion_status[0m
-[2m• [0mPath to captured crlf-lf.diff: _build/testo/status/testo_tests/ee1aad685657/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/ee1aad685657/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0mb23196a133ca [36mdiff[0m > [36mmissing-eol-only[0m                                 [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
@@ -2458,15 +2358,15 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-99/99 selected tests:
+95/99 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-98 new tests
+94 new tests
 overall status: [31mfailure[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
 <handling result before exiting>
-RUN ./test status -e foo=bar -l
+RUN ./test status -t 'not unix_only' -e foo=bar -l
 junk printed on stdout...
 ... when creating the test suite
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
@@ -2871,38 +2771,6 @@ junk printed on stdout...
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/360c4b690be4/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0me9a14b7e5dd9 [36mdiff[0m > [36mlf-crlf-only[0m                                     [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/e9a14b7e5dd9/completion_status[0m
-[2m• [0mPath to captured lf-crlf-only.diff: _build/testo/status/testo_tests/e9a14b7e5dd9/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/e9a14b7e5dd9/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m8f4b9e56ac4d [36mdiff[0m > [36mcrlf-lf-only[0m                                     [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8f4b9e56ac4d/completion_status[0m
-[2m• [0mPath to captured crlf-lf-only.diff: _build/testo/status/testo_tests/8f4b9e56ac4d/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8f4b9e56ac4d/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0m8339c60608b4 [36mdiff[0m > [36mlf-crlf[0m                                          [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/8339c60608b4/completion_status[0m
-[2m• [0mPath to captured lf-crlf.diff: _build/testo/status/testo_tests/8339c60608b4/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8339c60608b4/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
-[0m[2m│[0m [33m[MISS]  [0mee1aad685657 [36mdiff[0m > [36mcrlf-lf[0m                                          [2m│[0m
-[2m└──────────────────────────────────────────────────────────────────────────────┘
-[0m[2m• [0mChecked output: stdout
-[2m• [0m[31mMissing file containing the test output: _build/testo/status/testo_tests/ee1aad685657/completion_status[0m
-[2m• [0mPath to captured crlf-lf.diff: _build/testo/status/testo_tests/ee1aad685657/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/ee1aad685657/log
-[2m────────────────────────────────────────────────────────────────────────────────[0m
-[2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0mb23196a133ca [36mdiff[0m > [36mmissing-eol-only[0m                                 [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
@@ -3143,15 +3011,15 @@ junk printed on stdout...
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-99/99 selected tests:
+95/99 selected tests:
   1 skipped
   0 successful (0 pass, 0 xfail)
   0 unsuccessful (0 fail, 0 xpass)
-98 new tests
+94 new tests
 overall status: [31mfailure[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
 <handling result before exiting>
-RUN ./test status -e foo=bar -a
+RUN ./test status -t 'not unix_only' -e foo=bar -a
 junk printed on stdout...
 ... when creating the test suite
 [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m
@@ -3211,10 +3079,6 @@ junk printed on stdout...
 [33m[MISS]  [0m1cf5a6371f59 [36mdiff[0m > [36mtrailing-context[0m
 [33m[MISS]  [0m8ae0ad03ce59 [36mdiff[0m > [36mjoined-context[0m
 [33m[MISS]  [0m360c4b690be4 [36mdiff[0m > [36mgap-in-context[0m
-[33m[MISS]  [0me9a14b7e5dd9 [36mdiff[0m > [36mlf-crlf-only[0m
-[33m[MISS]  [0m8f4b9e56ac4d [36mdiff[0m > [36mcrlf-lf-only[0m
-[33m[MISS]  [0m8339c60608b4 [36mdiff[0m > [36mlf-crlf[0m
-[33m[MISS]  [0mee1aad685657 [36mdiff[0m > [36mcrlf-lf[0m
 [33m[MISS]  [0mb23196a133ca [36mdiff[0m > [36mmissing-eol-only[0m
 [33m[MISS]  [0mca552d6359ef [36mdiff[0m > [36mmissing-eol[0m
 [33m[MISS]  [0m08e4221951ee [36mcurrent test[0m
@@ -3254,7 +3118,7 @@ junk printed on stdout...
 [33m[MISS]  [0mbf55db9dc3f0 [36mshared context split output 1[0m
 [33m[MISS]  [0mcb28cacab289 [36mshared context split output 2[0m
 <handling result before exiting>
-RUN ./test run -e foo=bar -j 1 
+RUN ./test run -e foo=bar -j 1  -t 'not unix_only'
 junk printed on stdout...
 ... when creating the test suite
 Legend:
@@ -3606,30 +3470,6 @@ Try '--help' for options.
 [2m• [0mPath to expected gap-in-context.diff: tests/diff-data/gap-in-context.diff
 [2m• [0mPath to captured gap-in-context.diff: _build/testo/status/testo_tests/360c4b690be4/stdout
 [2m• [0mPath to captured log: _build/testo/status/testo_tests/360c4b690be4/log
-[33m[RUN][0m   e9a14b7e5dd9 [36mdiff[0m > [36mlf-crlf-only[0m
-[32m[PASS]  [0me9a14b7e5dd9 [36mdiff[0m > [36mlf-crlf-only[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected lf-crlf-only.diff: tests/diff-data/lf-crlf-only.diff
-[2m• [0mPath to captured lf-crlf-only.diff: _build/testo/status/testo_tests/e9a14b7e5dd9/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/e9a14b7e5dd9/log
-[33m[RUN][0m   8f4b9e56ac4d [36mdiff[0m > [36mcrlf-lf-only[0m
-[32m[PASS]  [0m8f4b9e56ac4d [36mdiff[0m > [36mcrlf-lf-only[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected crlf-lf-only.diff: tests/diff-data/crlf-lf-only.diff
-[2m• [0mPath to captured crlf-lf-only.diff: _build/testo/status/testo_tests/8f4b9e56ac4d/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8f4b9e56ac4d/log
-[33m[RUN][0m   8339c60608b4 [36mdiff[0m > [36mlf-crlf[0m
-[32m[PASS]  [0m8339c60608b4 [36mdiff[0m > [36mlf-crlf[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected lf-crlf.diff: tests/diff-data/lf-crlf.diff
-[2m• [0mPath to captured lf-crlf.diff: _build/testo/status/testo_tests/8339c60608b4/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/8339c60608b4/log
-[33m[RUN][0m   ee1aad685657 [36mdiff[0m > [36mcrlf-lf[0m
-[32m[PASS]  [0mee1aad685657 [36mdiff[0m > [36mcrlf-lf[0m
-[2m• [0mChecked output: stdout
-[2m• [0mPath to expected crlf-lf.diff: tests/diff-data/crlf-lf.diff
-[2m• [0mPath to captured crlf-lf.diff: _build/testo/status/testo_tests/ee1aad685657/stdout
-[2m• [0mPath to captured log: _build/testo/status/testo_tests/ee1aad685657/log
 [33m[RUN][0m   b23196a133ca [36mdiff[0m > [36mmissing-eol-only[0m
 [32m[PASS]  [0mb23196a133ca [36mdiff[0m > [36mmissing-eol-only[0m
 [2m• [0mChecked output: stdout
@@ -3776,9 +3616,9 @@ Try '--help' for options.
 2 folders no longer belong to the test suite and can be removed manually or with '--autoclean':
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-99/99 selected tests:
+95/99 selected tests:
   1 skipped
-  97 successful (90 pass, 7 xfail)
+  93 successful (86 pass, 7 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [32msuccess[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
@@ -3794,7 +3634,7 @@ RUN rm -rf tests/snapshots/testo_tests/f66d12950c64
 RUN rm -rf tests/snapshots/testo_tests/caadabfd495c
 RUN mkdir -p tests/custom-snapshots
 RUN rm -f tests/custom-snapshots/*
-RUN ./test status -e foo=bar 
+RUN ./test status -t 'not unix_only' -e foo=bar 
 junk printed on stdout...
 ... when creating the test suite
 [33m[PASS*] [0m9c96a5aa8b4b ([1mmeta[0m) [36mauto-approve[0m > [36mcapture stdout[0m
@@ -3808,7 +3648,7 @@ junk printed on stdout...
 [31m[FAIL]  [0m54ddc3c7d064 ([1mmeta[0m) [36mbroken[0m
 [33m[PASS*] [0mf66d12950c64 [36mauto-approve[0m > [36minternal files[0m > [36mcreate name file[0m
 <handling result before exiting>
-RUN ./test approve -e foo=bar -s auto-approve
+RUN ./test approve -t 'not unix_only' -e foo=bar -s auto-approve
 junk printed on stdout...
 ... when creating the test suite
 Expected output changed for 9 tests.
@@ -3816,7 +3656,7 @@ Expected output changed for 9 tests.
 #####################################################################
 # Delete the dead snapshots with --autoclean
 #####################################################################
-RUN ./test status -e foo=bar -l --autoclean
+RUN ./test status -t 'not unix_only' -e foo=bar -l --autoclean
 junk printed on stdout...
 ... when creating the test suite
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
@@ -3853,9 +3693,9 @@ junk printed on stdout...
 2 folders no longer belong to the test suite and are being removed:
   tests/snapshots/testo_tests/named-junk this is a ghost test that we keep around for meta tests
   tests/snapshots/testo_tests/unnamed-junk ??
-99/99 selected tests:
+95/99 selected tests:
   1 skipped
-  97 successful (90 pass, 7 xfail)
+  93 successful (86 pass, 7 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [32msuccess[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m
@@ -3863,7 +3703,7 @@ overall status: [32msuccess[0m
 #####################################################################
 # Check that the dead snapshots are gone
 #####################################################################
-RUN ./test status -e foo=bar -l
+RUN ./test status -t 'not unix_only' -e foo=bar -l
 junk printed on stdout...
 ... when creating the test suite
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
@@ -3897,9 +3737,9 @@ junk printed on stdout...
  Called from <MASKED>
  
 [2m────────────────────────────────────────────────────────────────────────────────[0m
-99/99 selected tests:
+95/99 selected tests:
   1 skipped
-  97 successful (90 pass, 7 xfail)
+  93 successful (86 pass, 7 xfail)
   1 unsuccessful (1 fail, 0 xpass)
 overall status: [32msuccess[0m
 [33mThe status of 1 "broken" test was ignored! Use '--strict' to override.[0m

--- a/util/lib/Helpers.mli
+++ b/util/lib/Helpers.mli
@@ -23,11 +23,15 @@ val make_dir_if_not_exists : ?recursive:bool -> Fpath.t -> unit
    Files are sorted alphabetically and don't include "." or "..". *)
 val list_files : Fpath.t -> string list
 
+(* Similar to In_channel.input_all which is available starting with
+   OCaml 4.14 *)
+val input_all : in_channel -> string
+
 (* Delete files recursively *)
 val remove_file_or_dir : Fpath.t -> unit
 val contains_pcre_pattern : pat:string -> string -> bool
 val contains_substring : sub:string -> string -> bool
-val write_file : Fpath.t -> string -> unit
-val read_file : Fpath.t -> string
-val map_file : (string -> string) -> Fpath.t -> Fpath.t -> unit
-val copy_file : Fpath.t -> Fpath.t -> unit
+val write_text_file : Fpath.t -> string -> unit
+val read_text_file : Fpath.t -> string
+val map_text_file : (string -> string) -> Fpath.t -> Fpath.t -> unit
+val copy_text_file : Fpath.t -> Fpath.t -> unit

--- a/util/lib/Multiprocess.ml
+++ b/util/lib/Multiprocess.ml
@@ -272,6 +272,10 @@ module Client = struct
     let ((std_in_ch, std_out_ch) as process) =
       Unix.open_process_args program_name argv
     in
+    (* Make sure to communicate over the pipe in binary mode to avoid
+       CRLF<->LF conversions *)
+    set_binary_mode_in std_in_ch true;
+    set_binary_mode_out std_out_ch true;
     let std_in_fd = Unix.descr_of_in_channel std_in_ch in
     let worker =
       {

--- a/util/lib/Tag_query_lexer.mll
+++ b/util/lib/Tag_query_lexer.mll
@@ -2,6 +2,7 @@
    Tokenizer for tag queries
 *)
 {
+  open Printf
   open Tag_query_parser
 }
 rule token = parse
@@ -18,3 +19,5 @@ rule token = parse
       TAG (Tag.of_string_exn tag_str)
     }
   | eof               { EOF }
+  | _ as c            { failwith (sprintf
+                                    "invalid character in tag query: %C" c) }


### PR DESCRIPTION
- The snapshots and logs are now all opened in text mode because they're meant to be reviewed by humans. This includes diffs produced by testo and direct inspection of files on disk.
- On the other hand, the communication over pipes between the master process and the workers was broken due writers being in text mode and emitting CRLFs while the reader was apparently in binary mode, receiving these CRLFs and not translating them into LFs. Communication between master and workers is now done in binary mode, preserving LFs and any binary data that might be sent through the pipe.

All the tests now pass on Windows 🎉

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.