### PR TITLE
Add -C/--chdir option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,11 @@ jobs:
           name: Build
           command: opam exec -- make
       - run:
-          name: Test
+          name: Test with Make
           command: opam exec -- make test
+      - run:
+          name: Test with Dune
+          command: opam exec -- dune runtest
   build_legacy:
     docker:
       - image: mjambon/mj-ocaml-4.08:alpine
@@ -49,8 +52,11 @@ jobs:
           name: Build
           command: opam exec -- make
       - run:
-          name: Test
+          name: Test with Make
           command: opam exec -- make test
+      - run:
+          name: Test with Dune
+          command: opam exec -- dune runtest
 
   windows_build:
     executor:
@@ -131,17 +137,11 @@ jobs:
       - run:
           name: Build
           shell: bash.exe
-          command: |
-            opam exec -- dune build .
+          command: opam exec -- dune build .
       - run:
           name: Test
           shell: bash.exe
-          command: |
-            set -e
-            opam exec -- dune exec diff/tests/test.exe
-            opam exec -- dune exec tests/test_alcotest.exe
-            opam exec -- dune exec tests/test.exe -- -t 'not meta'
-            opam exec -- dune exec tests/meta_test.exe
+          command: opam exec -- dune runtest
 
   semgrep-full-scan:
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,5 @@
 /_opam
 
 # Symbolic links created dynamically
-/failing-test
-/meta-test
-/parallel-test
-/test-alcotest
 /bin
 /tests/diff-data/testo-diff

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,8 @@ x.x.x (xxxx-xx-xx)
   `write_text_file`, `read_text_file`, etc.
   ([#165](https://github.com/semgrep/testo/pull/165)).
 * Testo's own test suite now passes successfully on Windows.
+* Add a `-C`/`--chdir` option to set the current working directory
+  ([#167](https://github.com/semgrep/testo/pull/167)).
 
 0.2.0 (2025-09-11)
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -9,18 +9,13 @@ build: symlinks
 # dune-release gets confused by dead symlinks so we create them dynamically
 .PHONY: symlinks
 symlinks:
-	ln -sf _build/default/tests/failing_test.exe failing-test
-	ln -sf _build/default/tests/parallel_test.exe parallel-test
-	ln -sf _build/default/tests/test_alcotest.exe test-alcotest
-	ln -sf _build/default/tests/meta_test.exe meta-test
 	ln -sf ../../bin/testo-diff tests/diff-data/testo-diff
 	# expose testo-diff in bin/
 	ln -sf _build/install/default/bin .
 
 .PHONY: delete-symlinks
 delete-symlinks:
-	rm -f failing-test parallel-test test-alcotest meta-test \
-	  tests/diff-data/testo-diff bin
+	rm -f tests/diff-data/testo-diff bin
 
 # Install opam dependencies. This requires pre-commit which requires
 # Python. See scripts/dev-setup-alpine for an example of how to install
@@ -29,6 +24,8 @@ delete-symlinks:
 setup:
 	./scripts/dev-setup-all-platforms
 
+# Run all the tests.
+# coupling: 'dune runtest' is also set up to run the same tests.
 .PHONY: test
 test: build
 	dune exec diff/tests/test.exe

--- a/core/Run.mli
+++ b/core/Run.mli
@@ -28,6 +28,7 @@ val cmd_run :
   is_worker:bool ->
   jobs:int option ->
   lazy_:bool ->
+  orig_cwd:Fpath.t option ->
   slice:Testo_util.Slice.t list ->
   strict:bool ->
   test_list_checksum:string option ->

--- a/core/Testo.ml
+++ b/core/Testo.ml
@@ -7,7 +7,6 @@
 
 open Printf
 open Testo_util
-open Fpath_.Operators
 module T = Types
 
 (****************************************************************************)
@@ -267,11 +266,7 @@ let read_file = read_text_file
 let map_file = map_text_file
 let copy_file = copy_text_file
 let with_temp_file = with_temp_text_file
-
-let with_chdir path func =
-  let orig_cwd = Unix.getcwd () in
-  Unix.chdir !!path;
-  Fun.protect ~finally:(fun () -> Unix.chdir orig_cwd) func
+let with_chdir = Helpers.with_chdir
 
 module Filename_old = struct
   (* The code in this submodule was copied from 'filename.ml' in

--- a/diff/tests/dune
+++ b/diff/tests/dune
@@ -1,3 +1,9 @@
+(rule
+ (alias runtest)
+ (deps test.exe)
+ (action (run ./test.exe))
+)
+
 ; Test program for testo-diff. It doesn't use Testo to as to keep things
 ; simple and modular.
 (executable

--- a/failing-test
+++ b/failing-test
@@ -1,0 +1,2 @@
+#! /usr/bin/env bash
+_build/default/tests/failing_test.exe "$@"

--- a/meta-test
+++ b/meta-test
@@ -1,0 +1,2 @@
+#! /usr/bin/env bash
+_build/default/tests/meta_test.exe "$@"

--- a/parallel-test
+++ b/parallel-test
@@ -1,0 +1,2 @@
+#! /usr/bin/env bash
+_build/default/tests/parallel_test.exe "$@"

--- a/test
+++ b/test
@@ -1,2 +1,13 @@
 #! /usr/bin/env bash
-_build/default/tests/test.exe "$@"
+#
+# Allow the test program to be invoked from anywhere
+#
+
+# Make the current directory the location of this script,
+# normally the project root.
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Run the compiled test program with the original arguments.
+# The path may have to be adjusted to match the
+# location of the binary built by Dune.
+./_build/default/tests/test.exe "$@"

--- a/test-alcotest
+++ b/test-alcotest
@@ -1,0 +1,2 @@
+#! /usr/bin/env bash
+_build/default/tests/test_alcotest.exe "$@"

--- a/tests/Test_alcotest.ml
+++ b/tests/Test_alcotest.ml
@@ -26,4 +26,4 @@ let () =
     ~handle_subcommand_result:(fun exit_code _res ->
       Printf.printf "Testo exit code: %i\n" exit_code;
       Testo.to_alcotest ~alcotest_skip:Alcotest.skip (tests [])
-      |> Alcotest.run "test-alcotest")
+      |> Alcotest.run ~argv:[| "<test alcotest>" |] "test-alcotest")

--- a/tests/dune
+++ b/tests/dune
@@ -1,3 +1,23 @@
+; Allow 'dune runtest' to run the tests from dune's copy of the project root.
+(rule
+ (alias runtest)
+ (deps
+   test_alcotest.exe
+   test.exe
+   meta_test.exe
+   parallel_test.exe  ; invoked by meta_test
+   timeout_test.exe  ; invoked by meta_test
+ )
+ (action
+   (progn
+     ; The -C argument should be a path to our source project's root
+     (run ./test_alcotest.exe -C ../../..)
+     (run ./test.exe -C ../../.. -t "not meta")
+     (run ./meta_test.exe -C ../../..)
+   )
+ )
+)
+
 ; Unit tests for internal modules of the Testo library and some "dummy" tests
 (executable
  (name test)

--- a/util/lib/Helpers.ml
+++ b/util/lib/Helpers.ml
@@ -139,3 +139,13 @@ let map_text_file func src_path dst_path =
 
 let copy_text_file src_path dst_path =
   map_text_file (fun data -> data) src_path dst_path
+
+let with_chdir path func =
+  let orig_cwd = Sys.getcwd () in
+  Sys.chdir !!path;
+  Fun.protect ~finally:(fun () -> Sys.chdir orig_cwd) func
+
+let with_opt_chdir opt_path func =
+  match opt_path with
+  | None -> func ()
+  | Some path -> with_chdir path func

--- a/util/lib/Helpers.mli
+++ b/util/lib/Helpers.mli
@@ -35,3 +35,7 @@ val write_text_file : Fpath.t -> string -> unit
 val read_text_file : Fpath.t -> string
 val map_text_file : (string -> string) -> Fpath.t -> Fpath.t -> unit
 val copy_text_file : Fpath.t -> Fpath.t -> unit
+
+(* Change the current directory temporarily *)
+val with_chdir : Fpath.t -> (unit -> 'a) -> 'a
+val with_opt_chdir : Fpath.t option -> (unit -> 'a) -> 'a

--- a/util/lib/Multiprocess.mli
+++ b/util/lib/Multiprocess.mli
@@ -23,6 +23,7 @@ module Client : sig
     num_workers:int ->
     on_end_test:('test -> unit) ->
     on_start_test:(worker option -> 'test -> unit) ->
+    orig_cwd:Fpath.t option ->
     test_list_checksum:string ->
     'test list ->
     (unit, string) result


### PR DESCRIPTION
This new option `-C` is similar to Git's `-C` and Make's `-C`. It allows changing the current working directory before starting any work. This allows running the tests from Dune while reading and writing test statuses and test snapshots in the source tree rather than in the copy created by Dune.

`dune runtest` now runs the same tests as `make test`, showing that it works.

Documentation on how to run tests with Dune will be done separately.

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.