### PR TITLE
Silence noisy git failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 0.3.3 (2026-01-17)
+## 0.3.4 (2026-01-17)
 
 - Add support for checked output files ([#134](https://github.com/semgrep/testo/issues/134)).
 - Add an option `inline_logs` to create a test for which logs are always or never shown inline ([#142](https://github.com/semgrep/testo/issues/142)).

--- a/tests/Meta_test.ml
+++ b/tests/Meta_test.ml
@@ -119,8 +119,7 @@ let clear_snapshots ~__LOC__:loc () =
   (* snapshots at the default location *)
   auto_approve_tests
   |> List.iter (fun id ->
-         shell_command ~__LOC__:loc
-           ("rm -rf tests/snapshots/testo_subtests/" ^ id));
+      shell_command ~__LOC__:loc ("rm -rf tests/snapshots/testo_subtests/" ^ id));
   (* snapshots at a custom location *)
   shell_command ~__LOC__:loc "mkdir -p tests/custom-snapshots";
   shell_command ~__LOC__:loc "rm -f tests/custom-snapshots/*"
@@ -132,9 +131,7 @@ let clear_snapshots ~__LOC__:loc () =
 *)
 let restore_git_snapshots ?(path = "tests/snapshots/testo_subtests") () =
   section "Restore deleted snapshots (best effort)";
-  shell_command ~__LOC__
-    (sprintf "git restore '%s' 2>&1 | grep -v 'did not match any file' || true"
-       path)
+  shell_command ~__LOC__ (sprintf "git restore '%s' 2> /dev/null || true" path)
 
 let test_standard_flow () =
   Fun.protect

--- a/tests/snapshots/testo_meta_tests/14c5e5fd13eb/stdxxx
+++ b/tests/snapshots/testo_meta_tests/14c5e5fd13eb/stdxxx
@@ -17,4 +17,4 @@ junk printed on stdout...
 #####################################################################
 # Restore deleted snapshots (best effort)
 #####################################################################
-RUN git restore 'tests/snapshots/testo_subtests/05dd9a9f220b/stdout' 2>&1 | grep -v 'did not match any file' || true
+RUN git restore 'tests/snapshots/testo_subtests/05dd9a9f220b/stdout' 2> /dev/null || true

--- a/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
+++ b/tests/snapshots/testo_meta_tests/fccf02a5c37e/stdxxx
@@ -515,4 +515,4 @@ overall status: [32msuccess[0m
 #####################################################################
 # Restore deleted snapshots (best effort)
 #####################################################################
-RUN git restore 'tests/snapshots/testo_subtests' 2>&1 | grep -v 'did not match any file' || true
+RUN git restore 'tests/snapshots/testo_subtests' 2> /dev/null || true


### PR DESCRIPTION
We were getting an error message on opam-repository's CI which runs our tests:

```
#  # Restore deleted snapshots (best effort)
#  #####################################################################
#  RUN git restore 'tests/snapshots/testo_subtests' 2>&1 | grep -v 'did not match any file' || true#  RUN git restore 'tests/snapshots/testo_subtests/05dd9a9f220b/stdout' 2>&1 | grep -v 'did not match any file' || true
# +fatal: not a git repository (or any parent up to mount point /)
# +Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

The error output of `git` is now completely silenced to avoid discrepancies in the output checked by testo when running outside of a Git repo.

This is now fixed and I'm going to attempt release 0.3.4. Fourth time's the charm?

PR checklist:

- [x] Purpose of the code is evident to future readers
- [x] Tests are included or a PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was added to `CHANGES.md` for any user-facing change

Check out [`CONTRIBUTING.md`](https://github.com/semgrep/testo/blob/main/CONTRIBUTING.md) for more details.